### PR TITLE
Fix CI: override entrypoint to prevent sshd hanging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Verify core tools are installed
         run: |
-          docker run --rm dotfiles-test:ci /bin/bash -c '
+          docker run --rm --entrypoint /bin/bash dotfiles-test:ci -c '
             eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
             echo "=== Checking core tools ==="
             for tool in hx bat fzf rg eza fd jq nnn doppler uv; do
@@ -52,7 +52,6 @@ jobs:
               fi
             done
             echo "=== Checking Node + Claude ==="
-            export PATH="/home/jth/.local/state/fnm_multishells/$(ls /home/jth/.local/state/fnm_multishells/)/bin:$PATH" 2>/dev/null || true
             eval "$(fnm env)" 2>/dev/null || true
             node --version || (echo "✗ node MISSING" && exit 1)
             claude --version || (echo "✗ claude MISSING" && exit 1)


### PR DESCRIPTION
## Summary
- The `docker run --rm` in the verify step was using the default entrypoint which starts tailscaled + sshd
- sshd runs in foreground (`-D`) so the container never exits
- Fix: `--entrypoint /bin/bash` bypasses the entrypoint and runs the check script directly

## Test plan
- [ ] Linux job completes without hanging
- [ ] All core tools verified
- [ ] GHCR push succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rregullo job-in e verifikimit në CI në mënyrë që kontrollet e core tools të bazuara në Docker të përfundojnë në vend që të bllokohen.

Rregullime gabimesh (Bug Fixes):
- Mbishkruaj entrypoint-in e kontejnerit Docker në hapin e verifikimit të CI-së për të ekzekutuar drejtpërdrejt skriptin e kontrollit të shell-it dhe për të shmangur procesin afatgjatë `sshd`.

CI:
- Përditëso komandën `docker run` në workflow-in e CI-së për të përdorur `/bin/bash` si entrypoint për verifikimin e core tools dhe thjeshto konfigurimin e mjedisit Node duke u mbështetur te `fnm env` në vend të një `PATH` të eksportuar me vlerë të koduar.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the CI verification job so the Docker-based core tools check runs to completion instead of hanging.

Bug Fixes:
- Override the Docker container entrypoint in the CI verify step to run the shell check script directly and avoid the long-running sshd process.

CI:
- Update the CI workflow's Docker run command to use /bin/bash as the entrypoint for core tool verification and simplify Node environment setup by relying on fnm env instead of a hard-coded PATH export.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow container invocation configuration for improved shell handling.

**Note:** This is an internal infrastructure change with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->