### PR TITLE
Sync OrbStack integration and remove stale gh config

### DIFF
--- a/dot_config/gh/private_hosts.yml
+++ b/dot_config/gh/private_hosts.yml
@@ -1,5 +1,0 @@
-github.com:
-    git_protocol: https
-    users:
-        Jobikinobi: {}
-    user: Jobikinobi

--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -1,5 +1,9 @@
 [user]
 	name = Joseph T. Herrmann, M.D.
 	email = joeherrmann@gmail.com
+[credential "https://github.com"]
+	helper = !/opt/homebrew/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper = !/opt/homebrew/bin/gh auth git-credential
 [coderabbit]
 	machineId = cli/19cd3f55acb74a54a3000e0aeb64f816

--- a/dot_zprofile
+++ b/dot_zprofile
@@ -1,2 +1,6 @@
 
 eval "$(/opt/homebrew/bin/brew shellenv zsh)"
+
+# Added by OrbStack: command-line tools and integration
+# This won't be added again if you remove it.
+source ~/.orbstack/shell/init.zsh 2>/dev/null || :

--- a/private_dot_ssh/config.tmpl
+++ b/private_dot_ssh/config.tmpl
@@ -1,4 +1,9 @@
 {{ if eq .chezmoi.os "darwin" -}}
+# Added by OrbStack: 'orb' SSH host for Linux machines
+# This only works if it's at the top of ssh_config (before any Host blocks).
+# This won't be added again if you remove it.
+Include ~/.orbstack/ssh/config
+
 Include /Users/jth/.colima/ssh_config
 
 {{ end -}}


### PR DESCRIPTION
## Summary
- Add OrbStack SSH and shell integration to chezmoi templates (macOS only)
- Remove unused `gh/private_hosts.yml`
- Baseline commit before project expansion to portable dev platform

## Test plan
- [ ] CI passes (Linux + macOS)
- [ ] OrbStack SSH include present in macOS rendered config
- [ ] OrbStack shell init present in zprofile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Përmbledhje nga Sourcery

Integrimi i mjeteve OrbStack në konfigurimin e mjedisit të zhvillimit në macOS dhe heqja e konfigurimit të vjetërsuar të host-it për GitHub CLI.

Veçori të reja:
- Përfshi konfigurimin e SSH të menaxhuar nga OrbStack në shabllonin e konfigurimit SSH për macOS për të mundësuar integrimin e host-it `orb`.
- Shto inicializimin e shell-it të OrbStack në profilin e zsh në mënyrë që mjetet OrbStack të jenë të disponueshme në shell-e interaktive në macOS.

Mirëmbajtje:
- Hiq nga depoja skedarin e papërdorur të konfigurimit `private_hosts` për GitHub CLI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate OrbStack tooling into macOS development environment configuration and remove obsolete GitHub CLI host configuration.

New Features:
- Include OrbStack-managed SSH configuration in the macOS SSH config template to enable the 'orb' host integration.
- Add OrbStack shell initialization to the zsh profile so OrbStack tools are available in interactive shells on macOS.

Chores:
- Remove the unused GitHub CLI private_hosts configuration file from the repository.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed legacy GitHub configuration entry
  * Integrated OrbStack shell initialization into startup process
  * Added OrbStack SSH configuration support on macOS

<!-- end of auto-generated comment: release notes by coderabbit.ai -->