### PR TITLE
feat(cloud-init): add Linux dotfiles handoff bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,81 @@ mac-save        # snapshot current state → commit → push
 mac-check       # show what has drifted (chezmoi diff)
 ```
 
+## Linux Cloud-Init Bootstrap (Two-Step Handoff)
+
+Use [`scripts/cloud-init/linux-dotfiles-handoff.yaml`](scripts/cloud-init/linux-dotfiles-handoff.yaml) as user-data when creating a new Linux VM (Ubuntu/Debian family).
+
+OrbStack example:
+
+```bash
+orb create ubuntu dotfiles-dev -c scripts/cloud-init/linux-dotfiles-handoff.yaml
+```
+
+What it does on first boot:
+
+1. Installs base prerequisites (`curl`, `git`, `sudo`, build toolchain, `zsh`)
+2. Creates two helper commands:
+  - `linux-bootstrap` (phase 1, set passwordless sudo + install Homebrew + install `chezmoi`)
+  - `dotfiles-restore` (phase 2, deploy dotfiles)
+
+Post-init deployment step:
+
+```bash
+sudo linux-bootstrap <your-linux-username>
+sudo dotfiles-restore <your-linux-username>
+```
+
+This runs:
+
+```bash
+chezmoi init --apply Jobikinobi
+```
+
+Notes:
+
+- On OrbStack, do not set a `users:` block in this file. OrbStack creates its own default login user matching your macOS username, and overriding user handling can cause first-boot setup conflicts.
+- `linux-bootstrap` is run manually after first login (this is more reliable on OrbStack than first-boot auto-run hooks for this workload).
+- `linux-bootstrap` configures passwordless sudo for the target user (`NOPASSWD`) to keep machine bring-up frictionless.
+- Helper scripts auto-detect the first non-system user when no username is passed.
+- The cloud-init file is designed to prepare immediately on first boot, then hand off cleanly to dotfiles deployment as a separate, explicit step.
+
+### OrbStack Smoke Test
+
+Use this quick checklist after creating a fresh machine:
+
+1. Create machine with cloud-init:
+
+```bash
+orb create ubuntu dotfiles-dev -c scripts/cloud-init/linux-dotfiles-handoff.yaml
+```
+
+2. SSH in and run bootstrap phase:
+
+```bash
+orb ssh dotfiles-dev
+sudo linux-bootstrap <your-linux-username>
+```
+
+3. Run restore phase:
+
+```bash
+sudo dotfiles-restore <your-linux-username>
+```
+
+4. Validate tooling and shell profile:
+
+```bash
+chezmoi doctor
+chezmoi diff
+zsh -lic 'command -v brew && command -v chezmoi && echo ok'
+```
+
+5. If secrets are used, verify encrypted file handling after key setup:
+
+```bash
+chezmoi apply --dry-run
+```
+
 ---
 
 ## Core Tool Stack (Linux + macOS)

--- a/scripts/cloud-init/linux-dotfiles-handoff.yaml
+++ b/scripts/cloud-init/linux-dotfiles-handoff.yaml
@@ -1,0 +1,119 @@
+#cloud-config
+
+package_update: true
+
+packages:
+  - curl
+  - git
+  - sudo
+  - zsh
+  - ca-certificates
+  - build-essential
+  - procps
+  - file
+  - passwd
+
+write_files:
+  - path: /usr/local/bin/linux-bootstrap
+    permissions: '0755'
+    owner: root:root
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      TARGET_USER="${1:-}"
+
+      if [[ -z "$TARGET_USER" ]] || ! id "$TARGET_USER" >/dev/null 2>&1; then
+        TARGET_USER="$(awk -F: '$3 >= 1000 && $1 != "nobody" && $1 != "ubuntu" {print $1; exit}' /etc/passwd)"
+      fi
+
+      if [[ -z "$TARGET_USER" ]] || ! id "$TARGET_USER" >/dev/null 2>&1; then
+        TARGET_USER="$(awk -F: '$3 >= 1000 && $1 != "nobody" {print $1; exit}' /etc/passwd)"
+      fi
+
+      if [[ -z "$TARGET_USER" ]]; then
+        echo "Could not determine target user" >&2
+        exit 1
+      fi
+
+      echo "Using target user: $TARGET_USER"
+
+      # Ensure sudo access for the login user.
+      usermod -aG sudo "$TARGET_USER" || true
+
+      # Ensure passwordless sudo for convenience in ephemeral/dev machines.
+      SUDOERS_FILE="/etc/sudoers.d/90-dotfiles-${TARGET_USER}"
+      printf '%s\n' "$TARGET_USER ALL=(ALL) NOPASSWD:ALL" > "$SUDOERS_FILE"
+      chmod 0440 "$SUDOERS_FILE"
+
+      if ! command -v brew >/dev/null 2>&1; then
+        echo "Installing Homebrew for Linux..."
+        su - "$TARGET_USER" -c 'NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+      fi
+
+      # Make brew available to all future login shells.
+      cat > /etc/profile.d/linuxbrew.sh <<'PROFILE'
+      if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+      elif [ -x "$HOME/.linuxbrew/bin/brew" ]; then
+        eval "$("$HOME/.linuxbrew/bin/brew" shellenv)"
+      fi
+      PROFILE
+      chmod 0644 /etc/profile.d/linuxbrew.sh
+
+      # Make brew immediately discoverable in common PATHs.
+      if [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]]; then
+        ln -sf /home/linuxbrew/.linuxbrew/bin/brew /usr/local/bin/brew
+      fi
+
+      if [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]]; then
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+      elif [[ -x /home/$TARGET_USER/.linuxbrew/bin/brew ]]; then
+        eval "$(/home/$TARGET_USER/.linuxbrew/bin/brew shellenv)"
+      fi
+
+      if ! su - "$TARGET_USER" -c 'command -v chezmoi >/dev/null 2>&1'; then
+        echo "Installing chezmoi..."
+        su - "$TARGET_USER" -c '
+          if [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]]; then
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          elif [[ -x "$HOME/.linuxbrew/bin/brew" ]]; then
+            eval "$("$HOME/.linuxbrew/bin/brew" shellenv)"
+          fi
+          brew install chezmoi
+        '
+      fi
+
+      echo "Bootstrap complete for $TARGET_USER"
+
+  - path: /usr/local/bin/dotfiles-restore
+    permissions: '0755'
+    owner: root:root
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      TARGET_USER="${1:-}"
+      if [[ -z "$TARGET_USER" ]] || ! id "$TARGET_USER" >/dev/null 2>&1; then
+        TARGET_USER="$(awk -F: '$3 >= 1000 && $1 != "nobody" {print $1; exit}' /etc/passwd)"
+      fi
+
+      if [[ -z "$TARGET_USER" ]]; then
+        echo "Could not determine target user" >&2
+        exit 1
+      fi
+
+      su - "$TARGET_USER" -c '
+        if [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]]; then
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        elif [[ -x "$HOME/.linuxbrew/bin/brew" ]]; then
+          eval "$("$HOME/.linuxbrew/bin/brew" shellenv)"
+        fi
+
+        command -v chezmoi >/dev/null 2>&1 || brew install chezmoi
+        chezmoi init --apply Jobikinobi
+      '
+
+      echo "Dotfiles restore complete for $TARGET_USER"
+
+final_message: 'Cloud-init complete. Run: sudo linux-bootstrap <user> && sudo dotfiles-restore <user>'

--- a/scripts/cloud-init/linux-minimal-auto.yaml
+++ b/scripts/cloud-init/linux-minimal-auto.yaml
@@ -1,0 +1,26 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+packages:
+  - build-essential
+  - gcc
+  - git
+  - curl
+
+runcmd:
+  # Create the log file directory and set permissions
+  - mkdir -p /var/log/custom-setup
+  - echo "=== Starting AI Dev Setup ===" >> /var/log/custom-setup/install-trace.txt
+  # Set environment for ubuntu user
+  - export HOME=/home/ubuntu
+  - export USER=ubuntu
+  # Install Homebrew for ubuntu user, log output
+  - (
+      sudo -u ubuntu -i curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh |
+      sudo -u ubuntu -i NONINTERACTIVE=1 bash
+    ) >> /var/log/custom-setup/install-trace.txt 2>&1
+  # Add Homebrew shellenv to bashrc/profile, log errors
+  - echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/ubuntu/.bashrc 2>> /var/log/custom-setup/install-trace.txt
+  - echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/ubuntu/.profile 2>> /var/log/custom-setup/install-trace.txt
+  - chown ubuntu:ubuntu /home/ubuntu/.bashrc /home/ubuntu/.profile 2>> /var/log/custom-setup/install-trace.txt
+  - echo "=== Setup Finished ===" >> /var/log/custom-setup/install-trace.txt


### PR DESCRIPTION
## Summary

- Add `scripts/cloud-init/linux-minimal-auto.yaml` and `scripts/cloud-init/linux-dotfiles-handoff.yaml` to bootstrap Linux VMs (OrbStack and similar) on first boot.
- Document the two-step handoff flow in the README so a new VM can bring itself up and then hand off to chezmoi to apply user dotfiles.

## Status

Initial baseline. Remaining scope (end-to-end OrbStack smoke test, chezmoi source repo confirmation, auto-run vs two-step decision on non-OrbStack distros, integration with `docs/architecture.md`) is tracked in #19 under milestone v2.0.0.

## Test plan

- [ ] OrbStack smoke test: launch a fresh Linux VM with the minimal-auto config and confirm first-boot completes.
- [ ] Run the handoff config and confirm `chezmoi apply` succeeds against the dotfiles source repo.
- [ ] README renders correctly on GitHub with the new section.

Refs #19