### PR TITLE
fix(Dockerfile.test): exclude encrypted files from standalone apply (THE-77)

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -87,7 +87,15 @@ RUN if [ -n "${CHEZMOI_PROJECT}" ]; then \
 # Step 3: apply with the correct projects list in place. This is where the
 # per-project brewfile loop in run_once_after_install-brewfile.sh.tmpl
 # actually fires for the active profile.
-RUN chezmoi apply --no-tty
+#
+# --exclude=encrypted: the repo contains age-encrypted ssh keys
+# (.ssh/id_ed25519_*.age). The decryption key (~/.config/chezmoi/key.txt) is
+# never present in CI by design (binary-presence-only verification, no
+# secrets), and standalone `chezmoi apply` errors on encrypted files when
+# encryption is configured but no key is available. The legacy
+# `chezmoi init --apply` path was apparently tolerant of this; the split
+# init/apply path isn't, so we exclude encrypted files explicitly.
+RUN chezmoi apply --no-tty --exclude=encrypted
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:${PATH}"
 
 # Switch back to root for entrypoint


### PR DESCRIPTION
## Summary

Single-commit fix to get the profile matrix green on `main`. Adds `--exclude=encrypted` to the standalone `chezmoi apply` step in `Dockerfile.test`.

## Root cause

After [#36](https://github.com/Jobikinobi/dotfiles/pull/36) split the legacy `chezmoi init --apply` into separate `init` + `apply` steps (so the per-project pre-seed of `chezmoi.toml` survives template rendering), every matrix leg started failing with:

```
chezmoi: .ssh/id_ed25519_macstudio.age: encryption not configured
```

`chezmoi init --apply` was tolerant of encrypted files when no decryption key was configured; standalone `chezmoi apply` is not. CI never has the age key by design (binary-presence-only verification, no secrets), so the apply step must explicitly skip encrypted files.

## The fix

```diff
-RUN chezmoi apply --no-tty
+RUN chezmoi apply --no-tty --exclude=encrypted
```

(Plus a comment block explaining why.)

## Test plan

- [ ] All four `profile/{core,legal,godocs,oversight}` legs SUCCESS on this PR.
- [ ] `linux` aggregator job SUCCESS.
- [ ] `macos` leg SUCCESS.
- [ ] Post-merge: intentional-regression test from [THE-72](/THE/issues/THE-72) acceptance (remove `tesseract` from `dot_Brewfile.legal` on a throwaway branch, confirm only `legal` leg fails).

Refs [THE-72](/THE/issues/THE-72), [THE-77](/THE/issues/THE-77).