### PR TITLE
DO NOT MERGE — intentional regression: tesseract removed from legal (THE-77)

### DIFF
--- a/dot_Brewfile.legal
+++ b/dot_Brewfile.legal
@@ -16,10 +16,8 @@
 # in Legal-Assistant-v3.
 brew "ghostscript"
 
-# Tesseract OCR fallback for non-macOS hosts. Apple Vision OCR (the primary
-# engine in av-ocr-rebuild) is macOS-only, so Linux containers in the `legal`
-# profile use Tesseract instead. Confirmed by board (THE-50 Q1 = YES).
-# English-only language data ships with the Homebrew formula and is sufficient
-# for v1 (Bill of Review, FOIA returns, Texas court records). Add
-# `tesseract-lang` later if a non-English corpus shows up.
-brew "tesseract"
+# INTENTIONAL REGRESSION — THE-77 acceptance test.
+# Tesseract removed on this throwaway branch to confirm the matrix actually
+# catches missing-binary regressions on the `legal` leg (and only `legal`).
+# DO NOT MERGE this branch. Revert before any normal work.
+# brew "tesseract"


### PR DESCRIPTION
## DO NOT MERGE

This is the intentional-regression test from [THE-72](/THE/issues/THE-72) acceptance, re-run per [THE-77](/THE/issues/THE-77) deliverable #4.

The branch removes `brew "tesseract"` from `dot_Brewfile.legal`. If the profile-matrix gate works, CI should show:

- `profile / core` → SUCCESS
- `profile / godocs` → SUCCESS
- `profile / oversight` → SUCCESS
- `profile / legal` → FAILURE (`tesseract` no longer on PATH inside the legal image)
- `linux` (aggregator) → FAILURE (because the matrix is not all-success)
- `macos` → SUCCESS (chezmoi apply path unaffected)

I'll capture the CI results, close this PR without merging, and delete the branch.