### PR TITLE
DO NOT MERGE — THE-79 acceptance: tesseract removed on top of hermetic-test fix

### DIFF
--- a/dot_Brewfile.legal
+++ b/dot_Brewfile.legal
@@ -16,10 +16,15 @@
 # in Legal-Assistant-v3.
 brew "ghostscript"
 
-# Tesseract OCR fallback for non-macOS hosts. Apple Vision OCR (the primary
-# engine in av-ocr-rebuild) is macOS-only, so Linux containers in the `legal`
-# profile use Tesseract instead. Confirmed by board (THE-50 Q1 = YES).
-# English-only language data ships with the Homebrew formula and is sufficient
-# for v1 (Bill of Review, FOIA returns, Texas court records). Add
-# `tesseract-lang` later if a non-English corpus shows up.
-brew "tesseract"
+# INTENTIONAL REGRESSION — THE-79 acceptance test (re-run of PR #39 on top
+# of the fix/the-79-test-profile-hermetic fix). Tesseract is removed here so
+# the matrix-gate verification actually fires. With the hermetic-test fix
+# in place, CI should now show:
+#   profile / core      → SUCCESS
+#   profile / godocs    → SUCCESS
+#   profile / oversight → SUCCESS
+#   profile / legal     → FAILURE (tesseract not on /home/linuxbrew/.linuxbrew/bin)
+#   linux (aggregator)  → FAILURE
+#   macos               → SUCCESS
+# DO NOT MERGE this branch. Close + delete after CI confirms.
+# brew "tesseract"

--- a/scripts/test-profile.sh
+++ b/scripts/test-profile.sh
@@ -379,6 +379,14 @@ else
   for bin in "${declared_binaries[@]}"; do
     if binary_on_path_in_image "$profile_tag" "$bin"; then
       printf '  ✓ %s\n' "$bin"
+      # THE-79 forensic mode: even successful assertions emit a one-line
+      # provenance summary. The PR #41 acceptance leg passed despite the
+      # regression branch commenting out `brew "tesseract"` — proving the
+      # fix's login-shell hypothesis was incomplete. We need the actual
+      # path each declared binary resolves to in order to identify the
+      # second source of pollution (cached layer, transitive dep, or
+      # base-image pre-staging). Remove this trace once root-caused.
+      diagnose_binary_in_image "$profile_tag" "$bin"
     else
       printf '  ✗ %s\n' "$bin" >&2
       diagnose_binary_in_image "$profile_tag" "$bin"

--- a/scripts/test-profile.sh
+++ b/scripts/test-profile.sh
@@ -234,9 +234,23 @@ build_image() {
 
 # Run a one-shot command in the built image. The default ENTRYPOINT is
 # entrypoint.sh which starts tailscaled/sshd; we bypass it explicitly.
+#
+# IMPORTANT: we deliberately use `bash -c` (NOT `bash -lc`). A login shell
+# sources /etc/profile and ~/.bash_profile, both of which can mutate the
+# binary-resolution environment in ways that mask the IMAGE'S real state:
+#   - dot_bash_profile unconditionally prepends /Users/jth/micromamba/bin
+#     (a stale macOS path) and sources $HOME/.cargo/env (PATH-augmenting).
+#   - dot_bashrc prepends /opt/homebrew/opt/postgresql@15/bin (macOS path).
+#   - Future operator-installed rc snippets could alias or shadow binary
+#     names (see THE-79 for the original false-negative report — a login
+#     shell made `command -v tesseract` succeed even when brew bundle had
+#     not installed it, breaking the matrix gate's credibility).
+# A non-login shell inherits PATH from the Dockerfile's ENV, which is the
+# ground truth we want the matrix to assert against. Callers that need
+# brew on PATH must eval shellenv themselves (see brew_formulae_in_image).
 run_in_image() {
   local tag="$1"; shift
-  docker run --rm --entrypoint /bin/bash "$tag" -lc "$*"
+  docker run --rm --entrypoint /bin/bash "$tag" -c "$*"
 }
 
 # brew list --formula inside the image, sorted. Wraps the shellenv eval so
@@ -252,6 +266,47 @@ brew_formulae_in_image() {
     fi
     brew list --formula 2>/dev/null | LC_ALL=C sort -u
   '
+}
+
+# Hermetic binary-presence check used by the populated-profile assertion.
+# Wraps `command -v` in a non-login bash and adds the brew prefix to PATH
+# without sourcing any user rc files. Returns 0 if the binary resolves,
+# non-zero otherwise. Suppresses stdout/stderr — callers only inspect $?.
+binary_on_path_in_image() {
+  local tag="$1" bin="$2"
+  # shellcheck disable=SC2016
+  run_in_image "$tag" '
+    if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+      eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+    fi
+    command -v '"$(printf '%q' "$bin")"' >/dev/null 2>&1
+  '
+}
+
+# Diagnostic dump used when a binary-presence assertion FAILS or appears
+# anomalous. Prints (a) the PATH the test saw, (b) all hits along PATH
+# (`which -a`), (c) what `type -a` thinks the name refers to (alias,
+# function, builtin, file), (d) whether a matching file exists under the
+# Homebrew prefix, and (e) any brew formula matching the name. Together
+# these answer "if the gate fired wrong, where did the false signal come
+# from?" without a second CI round-trip.
+diagnose_binary_in_image() {
+  local tag="$1" bin="$2"
+  printf '%s: diagnostic for "%s" in %s:\n' "$PROG" "$bin" "$tag" >&2
+  # shellcheck disable=SC2016
+  run_in_image "$tag" '
+    if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+      eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+    fi
+    bin='"$(printf '%q' "$bin")"'
+    printf "    PATH=%s\n" "$PATH"
+    printf "    which -a:\n"; which -a "$bin" 2>&1 | sed "s/^/      /" || true
+    printf "    type -a:\n";  type -a  "$bin" 2>&1 | sed "s/^/      /" || true
+    printf "    ls -la \$HOMEBREW_PREFIX/bin/%s:\n" "$bin"
+    ls -la "/home/linuxbrew/.linuxbrew/bin/$bin" 2>&1 | sed "s/^/      /" || true
+    printf "    brew list --formula | grep -i %s:\n" "$bin"
+    brew list --formula 2>/dev/null | grep -i "$bin" | sed "s/^/      /" || printf "      (no match)\n"
+  ' >&2 || true
 }
 
 # Cleanup intermediate images unless --keep-images was set.
@@ -322,10 +377,11 @@ else
 
   missing=()
   for bin in "${declared_binaries[@]}"; do
-    if run_in_image "$profile_tag" "command -v $(printf '%q' "$bin") >/dev/null 2>&1"; then
+    if binary_on_path_in_image "$profile_tag" "$bin"; then
       printf '  ✓ %s\n' "$bin"
     else
       printf '  ✗ %s\n' "$bin" >&2
+      diagnose_binary_in_image "$profile_tag" "$bin"
       missing+=("$bin")
     fi
   done


### PR DESCRIPTION
## DO NOT MERGE

Re-runs PR #39's intentional regression on top of the [`fix/the-79-test-profile-hermetic`](https://github.com/Jobikinobi/dotfiles/tree/fix/the-79-test-profile-hermetic) fix for [THE-79](/THE/issues/THE-79).

## Expected CI

| Check | Expected |
| --- | --- |
| `profile / core` | SUCCESS |
| `profile / godocs` | SUCCESS |
| `profile / oversight` | SUCCESS |
| `profile / legal` | **FAILURE** (tesseract no longer on PATH; matrix gate fires) |
| `linux` (aggregator) | FAILURE |
| `macos` | SUCCESS |

If the legal leg fails as expected, the THE-79 fix is verified — close + delete this branch, then merge the companion fix PR.

If the legal leg still passes (false negative recurs), the diagnostic helper added in `scripts/test-profile.sh` will print PATH, `which -a tesseract`, `type -a tesseract`, the `/home/linuxbrew/.linuxbrew/bin/tesseract` listing, and `brew list | grep tesseract` directly in the CI log — enough to identify the next hypothesis without another round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)