### PR TITLE
Add Headscale migration playbook and per-OS join recipes

### DIFF
--- a/docs/homelab/README.md
+++ b/docs/homelab/README.md
@@ -150,6 +150,21 @@ fine — different prefix. Public keys are reconstructable on demand:
 - **Reformat workstations to Linux** and migrate them to PVE-hosted VMs
   (long-term north star, per the original goal statement).
 
+## Headscale migration (in progress)
+
+Separate effort tracked in [`headscale/`](headscale/): moving the entire
+hole-network off public Tailscale (`lemming-likert.ts.net`) onto self-hosted
+Headscale at `hs.lab.hole-truth.org`. Headscale gives us ownership of MagicDNS,
+control-plane TLS, and the per-node reverse proxy, which unblocks
+multi-HTTP-per-node service deployment.
+
+- [`headscale/README.md`](headscale/README.md) — entry point + current state
+- [`headscale/architecture.md`](headscale/architecture.md) — target end-state
+- [`headscale/cutover-playbook.md`](headscale/cutover-playbook.md) — operator procedure
+- [`headscale/rollback.md`](headscale/rollback.md) — get back to public Tailscale fast
+- [`headscale/reverse-proxy.md`](headscale/reverse-proxy.md) — Caddy reference
+- [`headscale/per-os/`](headscale/per-os/) — per-OS join recipes
+
 ## Conventions
 
 - VMID `9000-9999` = templates by convention (community pattern, not enforced).

--- a/docs/homelab/headscale/README.md
+++ b/docs/homelab/headscale/README.md
@@ -1,0 +1,76 @@
+# Headscale on the hole-network
+
+This directory documents the migration of the hole-network off public Tailscale (`lemming-likert.ts.net`) onto self-hosted Headscale (`hs.lab.hole-truth.org`). Headscale gives us a mesh where **we** own MagicDNS, control-plane TLS, and ingress — the underlying reason being that public Tailscale effectively caps a node at one HTTPS service via its `serve` / `funnel` model, and the long-term plan is multi-HTTP per node behind our own reverse proxy.
+
+Everything in `docs/**` is repo-internal (filtered out of `chezmoi apply` by `.chezmoiignore`). The cutover scripts that actually touch machine state will land separately in `bin/` and `scripts/headscale/` in a follow-up PR — see "What is NOT here" below.
+
+## What lives here
+
+| File | Audience | Purpose |
+|------|----------|---------|
+| [`architecture.md`](architecture.md) | engineer onboarding to the mesh | Ports, names, DNS plan, control-plane shape. Target end-state — what the network looks like after the migration is done. |
+| [`cutover-playbook.md`](cutover-playbook.md) | the operator running a cutover | The how-to. One machine at a time, with a held-open LAN SSH session, with rollback every step of the way. **The main deliverable of this doc set.** |
+| [`rollback.md`](rollback.md) | the operator during a cutover that's gone wrong | The five-minute path back to public Tailscale. Practiced on a disposable VM before any production machine is touched. |
+| [`reverse-proxy.md`](reverse-proxy.md) | engineer adding services to a Headscale-managed node | Caddy reference config for running multiple HTTP services on one node behind the tailnet. Stage-1 is HTTP-only over the mesh — per-node TLS is a follow-on. |
+| [`per-os/linux-debian.md`](per-os/linux-debian.md) | operator cutting over a Debian/Ubuntu host | Concrete per-OS join recipe. The path the trial nodes (`linux-test-01`, `linux-test-02`) actually took. |
+| [`per-os/linux-alpine.md`](per-os/linux-alpine.md) | operator cutting over an Alpine host | Skeleton — to be filled in when the Alpine lab-controller (`.74`) join happens. |
+| [`per-os/macos-oss.md`](per-os/macos-oss.md) | operator cutting over a Mac running the open-source Tailscale brew build | Recipe + measured-on-lume baseline (macOS 26.5 arm64). |
+| [`per-os/macos-appstore.md`](per-os/macos-appstore.md) | operator cutting over a Mac running the App Store Tailscale | The `defaults write io.tailscale.ipn.macos ControlURL …` quirk. Skeleton — fills in after the lume cutover experiment exercises it. |
+
+## Current state (as of 2026-06-04)
+
+| Component | Where | Status |
+|-----------|-------|--------|
+| Headscale control plane | VM 112 on PVE, IP `192.168.68.77`, accessed as `https://hs.lab.hole-truth.org` | Healthy. nginx terminates TLS via certbot DNS-01 LE cert. **Slated to swap to Caddy** — see "Hard prerequisite" below. |
+| Trial node `linux-test-01` | QEMU VM 108 on PVE, IP `192.168.68.70`, tailnet `100.64.0.1` | Joined. MagicDNS works (`linux-test-01.tail.lab.hole-truth.org`). |
+| Trial node `linux-test-02` | LXC 102 on PVE, tailnet `100.64.0.2` | Joined. Bidirectional ping with `-01` works. |
+| MagicDNS base domain | `tail.lab.hole-truth.org` | Active inside the tailnet. Not publicly resolvable yet (deferred). |
+| Internal DNS for `hs.lab.hole-truth.org` | `/etc/hosts` line on each joined node | **Provisional.** Long-term plan: publish in the `ddns` LXC (`.55`), then split-horizon. |
+| Lume macOS VM | `Josephs-Virtual-Machine.local` at `192.168.64.2` (macOS 26.5 arm64) | Probed 2026-06-04 — outbound to `.77:443` works, TLS handshake validates, no Tailscale installed yet. The cutover experiment runs here before any real Mac. |
+| Daily-driver Macs (Mac Studio, MacBook Air, Mac Mini) | Public Tailscale tailnet `lemming-likert.ts.net` | Untouched. Cutover order: Mac Studio LAST. |
+
+## Hard prerequisite: Caddy on `.77`
+
+The cutover playbook is written around Caddy as the standard reverse proxy across the Headscale network. `.77` currently runs nginx for control-plane TLS termination. Until that swap is completed (separate issue: "Swap nginx for Caddy on .77 as headscale control-plane TLS terminator"), the playbook is documentation-only — **do not onboard a virgin node yet**, or you commit the network to two different reverse-proxy patterns and have to migrate one of them later.
+
+The trial nodes already on the mesh are unaffected by this prerequisite — they keep working through and after the nginx → Caddy swap.
+
+## Cutover order
+
+The playbook executes machines one at a time, with explicit go-ahead per machine. Suggested order (least load-bearing first):
+
+1. Disposable lume macOS VM (the cutover experiment — proves the macOS path on Tahoe arm64)
+2. Alpine lab-controller `.74` (when powered on)
+3. New trial Linux VMs (cheap to redeploy)
+4. `mac-mini` (secondary workstation)
+5. `macbook-air` (mobile workstation)
+6. `my-vm` / `udev` (`.66` — primary development VM)
+7. **Mac Studio LAST** — the workstation we cannot afford to lose
+
+A cutover requires:
+- A second SSH session over the **LAN IP** (not tailnet) held open through the operation.
+- The rollback script ready in a third terminal.
+- The previous machine successfully cut over and observed for at least 24 hours.
+
+## What is NOT here
+
+- **No scripts.** The actual `cutover.sh` / `rollback.sh` / `preflight.sh` land in `scripts/headscale/` in a follow-up PR. Until then, the cutover-playbook documents what to run by hand.
+- **No automatic execution.** Nothing in this directory is wired into `chezmoi apply`. Network identity changes are deliberate human acts, not batch operations.
+- **No control-plane server bootstrap.** How `.77` is provisioned (the Ubuntu VM, the `/etc/headscale/config.yaml`, the certbot setup) lives in [hole-devenv](https://github.com/Jobikinobi/hole-devenv) — the infrastructure layer. This directory is purely the client-side / network-identity perspective.
+- **No internal DNS automation.** The plan to publish `hs.lab.hole-truth.org` via the `ddns` LXC at `.55`, and later split-horizon, is tracked separately.
+
+## Why dotfiles is the right home for this
+
+Every machine in the hole-network already has this repo deployed. That means:
+
+- The playbook and the (future) cutover scripts are present on a machine **before** any cutover begins, just by virtue of `chezmoi apply` having run at any point in the machine's history.
+- The operator doesn't have to fetch this doc on a held-open SSH session; it's already at `~/dotfiles/docs/homelab/headscale/cutover-playbook.md` on the machine they're SSHed into.
+- A future fresh machine inherits the same toolkit just by being initialized from dotfiles — no separate provisioning step to remember.
+
+This is the same logic that puts `dot_Brewfile.legal` in the repo rather than in a separate package: the cross-machine artifact rides with the cross-machine config delivery system.
+
+## Related
+
+- `docs/homelab/README.md` — the broader homelab project this is part of
+- `docs/homelab/recovery.md` — age-identity recovery (separate concern, but shares the "cannot afford to lose this" risk profile)
+- [hole-devenv](https://github.com/Jobikinobi/hole-devenv) — the infrastructure layer where the `.77` VM bootstrap actually lives

--- a/docs/homelab/headscale/architecture.md
+++ b/docs/homelab/headscale/architecture.md
@@ -1,0 +1,151 @@
+# Headscale architecture — target end-state
+
+This document describes what the hole-network looks like once the migration to Headscale is complete. It is **not** an installation guide — for the operator-facing cutover procedure see [`cutover-playbook.md`](cutover-playbook.md). For per-OS join recipes see [`per-os/`](per-os/).
+
+Some of what is described here (Caddy as the control-plane reverse proxy, per-node `tailscale cert`, public DNS publication of the base domain) is the **target state**, not the live state. Each section flags the delta from today.
+
+## Component map
+
+```
+                                ┌─────────────────────────────────┐
+                                │  Mac clients / Linux clients    │
+                                │  (Tailscale client + login-     │
+                                │   server pointed at headscale)  │
+                                └────────────────┬────────────────┘
+                                                 │ HTTPS (control)
+                                                 │ + WireGuard UDP (data)
+                                                 │
+                                                 ▼
+                                 https://hs.lab.hole-truth.org
+                                                 │
+                              (internal DNS or /etc/hosts → 192.168.68.77)
+                                                 │
+                                                 ▼
+                                ┌─────────────────────────────────┐
+                                │  Headscale VM (PVE VMID 112)    │
+                                │  192.168.68.77                  │
+                                │                                 │
+                                │  Caddy on :443                  │  ← target state
+                                │  (LE cert via DNS-01)           │     today: nginx
+                                │     │                           │
+                                │     ▼                           │
+                                │  headscale on 127.0.0.1:8080    │
+                                │  (control plane v0.28.0)        │
+                                └─────────────────────────────────┘
+```
+
+The Headscale VM is **only** a control plane. It does not run the Tailscale client itself — that is policy and there is no good reason to violate it. (Running `tailscaled` on the box that's also running headscale produces confusing interactions around MagicDNS, routes, and relay behavior.)
+
+## Host inventory
+
+| Role | Hardware | LAN IP | Tailnet IP | Notes |
+|------|----------|--------|------------|-------|
+| Headscale control plane | VM 112 on PVE | `192.168.68.77` | — (not a client) | Ubuntu. Caddy + headscale. Snapshot `before-headscale-lab` exists. |
+| Trial node `linux-test-01` | QEMU VM 108 on PVE | `192.168.68.70` | `100.64.0.1` | Joined as user `lab`. Has `/etc/hosts` entry for `hs.lab.hole-truth.org`. |
+| Trial node `linux-test-02` | LXC 102 on PVE | (DHCP) | `100.64.0.2` | LXC required `lxc.cgroup2.devices.allow: c 10:200 rwm` + `lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file` + `features: nesting=1`. |
+| PVE host | bare metal | `192.168.68.86` | — | Hypervisor for all the above. Console of last resort during cutover. |
+| Alpine lab-controller (planned) | VM 107 on PVE | `192.168.68.74` | TBD | Currently offline. Will join via the Alpine recipe — separate issue. |
+| Mac Studio | Apple Silicon | `192.168.68.168` | `100.94.84.6` (public TS, today) | Daily-driver workstation. Last machine to migrate. |
+| Mac Mini | Apple Silicon | `192.168.68.68` | `100.119.161.120` (public TS, today) | |
+| MacBook Air | Apple Silicon | `192.168.68.70` (collides with `linux-test-01` LAN — but different MAC and only one is ever up at a time on the same DHCP lease) | `100.115.1.29` (public TS, today) | |
+| Lume macOS VM | guest of Mac Studio | `192.168.64.2` (lume vmnet) | — (no Tailscale yet) | Disposable. Where the macOS cutover experiment runs. |
+
+The IP collision between `linux-test-01` (DHCP `.70`) and the MacBook Air (DHCP `.70` in the homelab README snapshot) is a tracker item — fine in practice today because they are never online at the same time on the same lease, but worth reserving distinct addresses on the router before the cutover gets to laptops.
+
+## Naming
+
+| Name | Resolves to | Owned by |
+|------|-------------|----------|
+| `hs.lab.hole-truth.org` | `192.168.68.77` | Internal DNS (target) / `/etc/hosts` line per joined node (today) |
+| `<hostname>.tail.lab.hole-truth.org` | tailnet IP for `<hostname>` | Headscale MagicDNS |
+| `<short-hostname>` | tailnet IP for `<hostname>` | Headscale MagicDNS (search-domain expansion) |
+| `<hostname>.lan.lab.hole-truth.org` | LAN IP (future routed services) | Headscale `extra_records` (small) / split DNS (large) |
+
+The DNS plan has three phases:
+
+1. **Today** — Every joined node carries a `/etc/hosts` line: `192.168.68.77 hs.lab.hole-truth.org`. Trial nodes use this. The cutover playbook installs this line as part of the join.
+2. **Medium term** — Publish `hs.lab.hole-truth.org` → `192.168.68.77` in the LAN's internal DNS (the `ddns` LXC at `.55` is the planned home). Joined nodes drop the `/etc/hosts` line and rely on resolver chain.
+3. **Long term (optional)** — Split horizon: `hs.lab.hole-truth.org` resolves to `.77` internally and to the WAN IP externally (with router-side TCP 443 forward to `.77:443`). Required only if we want to onboard nodes from outside the LAN.
+
+## Control-plane TLS
+
+**Today**: nginx on `.77:443` terminates a Let's Encrypt cert for `hs.lab.hole-truth.org` issued via certbot's DNS-01 challenge through Cloudflare. nginx proxies to `127.0.0.1:8080` (headscale) with the WebSocket-upgrade map required by Tailscale clients.
+
+**Target**: Caddy on `.77:443` does the same job, with cert renewal either remaining under certbot's control (conservative) or transitioning to Caddy's own ACME flow (clean). The swap is its own issue — a hard prerequisite for onboarding any virgin node, as it changes the reference reverse-proxy pattern documented in [`reverse-proxy.md`](reverse-proxy.md).
+
+Headscale itself never terminates TLS in this setup. Every client registration goes through whichever reverse proxy is currently in front.
+
+## Headscale config (key invariants)
+
+```yaml
+server_url: https://hs.lab.hole-truth.org
+listen_addr: 127.0.0.1:8080
+metrics_listen_addr: 127.0.0.1:9090
+
+tls_cert_path: ""        # TLS is handled by the front reverse proxy, NOT headscale
+tls_key_path: ""
+
+dns:
+  magic_dns: true
+  base_domain: tail.lab.hole-truth.org
+  override_local_dns: true
+  nameservers:
+    global:
+      - 1.1.1.1
+      - 1.0.0.1
+      - 2606:4700:4700::1111
+      - 2606:4700:4700::1001
+    split: {}
+  search_domains: []
+  extra_records: []
+```
+
+Notes:
+
+- `tls_*` are empty by design — headscale is HTTP-only on loopback, the reverse proxy handles TLS.
+- `magic_dns: true` + `base_domain` set is what makes `<hostname>.tail.lab.hole-truth.org` work without per-host `/etc/hosts` entries on joined nodes.
+- `override_local_dns: true` makes the tailnet DNS the resolver for joined clients while connected. If a node has a local DNS service that must keep authority, set this to `false` and rely on search-domain expansion instead.
+- `split` is empty for now. When the `lan.lab.hole-truth.org` zone is delegated to a real internal resolver, populate this so `.lan.` lookups go to the right place.
+- `extra_records` is empty. For small routed-LAN tests (e.g., a single internal-only service that isn't on the tailnet), an `extra_records` entry is the lightest possible name registration. For more than a handful of records, switch to split DNS.
+
+## Cert renewal
+
+`certbot` runs as a snap on `.77` with the `certbot-dns-cloudflare` plugin. Renewal uses DNS-01 against the `hole-truth.org` zone in Cloudflare. The Cloudflare API token is scoped to `Zone:DNS:Edit` + `Zone:Zone:Read` on `hole-truth.org` only.
+
+**Open security item**: the original Cloudflare API token was exposed in terminal output during initial setup. Treat it as compromised. The rotation is part of the cert handoff inside the Caddy-swap issue.
+
+`certbot renew --dry-run` succeeds today.
+
+## Auth keys
+
+User `lab` is the operating identity for the trial. Preauth keys are short-lived where possible (24h for single-shot, reusable for iterating). The CLAUDE recipe is:
+
+```bash
+# On .77 (headscale group member, no sudo needed for headscale CLI)
+headscale preauthkeys create --user lab --reusable --expiration 24h
+```
+
+For long-lived nodes (post-trial), each node gets its own one-time preauth key, used once, then discarded.
+
+**Do not bake reusable long-lived auth keys into a template that will be reused across machines.** A leaked template + a reusable key = arbitrary node enrollment.
+
+## Lockout prevention (architectural)
+
+- The Headscale control-plane VM is administered exclusively over LAN SSH (`192.168.68.77`) and the Proxmox console — never via the tailnet. Losing the tailnet must not lose the control plane.
+- Every joined node retains LAN SSH reachability — public Tailscale and Headscale are both "extra" access paths, never the only one.
+- Proxmox snapshots are the cheap rollback. The existing `before-headscale-lab` snapshot on VM 112 + `pre-caddy-swap` (added by the Caddy-swap issue) cover the high-risk operations.
+- The `headscale users delete <user>` command will deregister every node owned by that user. Do not delete `lab` once production nodes are joined under it.
+
+## Things this architecture does **not** do (today)
+
+- **External enrollment.** No router-side port forward is set up; no Cloudflare-proxied public exposure. Onboarding from outside the LAN requires either the medium-term DNS phase + a port forward, or VPN-in-then-join.
+- **Per-node TLS for services.** Stage 1 ships internal HTTP over the tailnet for multi-HTTP-per-node use cases. Per-node `tailscale cert` issuance is a follow-on (separate issue).
+- **Subnet routing.** No `--advertise-routes` on any joined node yet. Once a node is added as a subnet router (the planned `route-prox-01` role), routes are explicitly approved via `headscale nodes approve-routes`.
+- **ACLs.** Headscale runs with the default open-mesh policy. Tightening ACLs is a post-migration concern.
+- **Tailscale Funnel equivalent.** Headscale does not have a "public Funnel" feature. Public exposure of an internal service goes through the standard reverse-proxy + DNS path, not the mesh.
+
+## Related
+
+- [`cutover-playbook.md`](cutover-playbook.md) — operator procedure
+- [`rollback.md`](rollback.md) — get back to public Tailscale fast
+- [`reverse-proxy.md`](reverse-proxy.md) — Caddy reference for multi-HTTP per node

--- a/docs/homelab/headscale/architecture.md
+++ b/docs/homelab/headscale/architecture.md
@@ -2,7 +2,7 @@
 
 This document describes what the hole-network looks like once the migration to Headscale is complete. It is **not** an installation guide — for the operator-facing cutover procedure see [`cutover-playbook.md`](cutover-playbook.md). For per-OS join recipes see [`per-os/`](per-os/).
 
-Some of what is described here (Caddy as the control-plane reverse proxy, per-node `tailscale cert`, public DNS publication of the base domain) is the **target state**, not the live state. Each section flags the delta from today.
+Some of what is described here (per-node `tailscale cert`, public DNS publication of the base domain) is the **target state**, not the live state. Each section flags the delta from today. Caddy as the control-plane reverse proxy IS live as of 2026-06-05 (HOL-12).
 
 ## Component map
 
@@ -25,8 +25,12 @@ Some of what is described here (Caddy as the control-plane reverse proxy, per-no
                                 │  Headscale VM (PVE VMID 112)    │
                                 │  192.168.68.77                  │
                                 │                                 │
-                                │  Caddy on :443                  │  ← target state
-                                │  (LE cert via DNS-01)           │     today: nginx
+                                │  Caddy on :443                  │
+                                │  (LE cert via certbot DNS-01,   │
+                                │   reloaded on renewal via       │
+                                │   /etc/letsencrypt/renewal-     │
+                                │   hooks/deploy/01-reload-       │
+                                │   caddy.sh)                     │
                                 │     │                           │
                                 │     ▼                           │
                                 │  headscale on 127.0.0.1:8080    │
@@ -40,7 +44,7 @@ The Headscale VM is **only** a control plane. It does not run the Tailscale clie
 
 | Role | Hardware | LAN IP | Tailnet IP | Notes |
 |------|----------|--------|------------|-------|
-| Headscale control plane | VM 112 on PVE | `192.168.68.77` | — (not a client) | Ubuntu. Caddy + headscale. Snapshot `before-headscale-lab` exists. |
+| Headscale control plane | VM 112 on PVE | `192.168.68.77` | — (not a client) | Ubuntu. Caddy + headscale (nginx still installed but disabled — rollback insurance). Snapshots: `before-headscale-lab`, `headscale-working`, `pre-caddy-swap`. |
 | Trial node `linux-test-01` | QEMU VM 108 on PVE | `192.168.68.70` | `100.64.0.1` | Joined as user `lab`. Has `/etc/hosts` entry for `hs.lab.hole-truth.org`. |
 | Trial node `linux-test-02` | LXC 102 on PVE | (DHCP) | `100.64.0.2` | LXC required `lxc.cgroup2.devices.allow: c 10:200 rwm` + `lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file` + `features: nesting=1`. |
 | PVE host | bare metal | `192.168.68.86` | — | Hypervisor for all the above. Console of last resort during cutover. |
@@ -69,11 +73,32 @@ The DNS plan has three phases:
 
 ## Control-plane TLS
 
-**Today**: nginx on `.77:443` terminates a Let's Encrypt cert for `hs.lab.hole-truth.org` issued via certbot's DNS-01 challenge through Cloudflare. nginx proxies to `127.0.0.1:8080` (headscale) with the WebSocket-upgrade map required by Tailscale clients.
+Caddy on `.77:443` terminates a Let's Encrypt cert for `hs.lab.hole-truth.org` issued via certbot's DNS-01 challenge through Cloudflare. Caddy proxies to `127.0.0.1:8080` (headscale); the upgrade-header dance nginx needed is automatic in Caddy's `reverse_proxy` directive.
 
-**Target**: Caddy on `.77:443` does the same job, with cert renewal either remaining under certbot's control (conservative) or transitioning to Caddy's own ACME flow (clean). The swap is its own issue — a hard prerequisite for onboarding any virgin node, as it changes the reference reverse-proxy pattern documented in [`reverse-proxy.md`](reverse-proxy.md).
+Cert renewal stays under certbot's control (the "conservative" handoff from HOL-12). When certbot writes a renewed cert, `/etc/letsencrypt/renewal-hooks/deploy/01-reload-caddy.sh` runs `systemctl reload caddy`, which causes Caddy to re-read the cert files in place — no downtime.
 
-Headscale itself never terminates TLS in this setup. Every client registration goes through whichever reverse proxy is currently in front.
+nginx remains installed on the box but its unit is disabled. Rollback is `systemctl stop caddy; systemctl start nginx` (the nginx config still lives at `/etc/nginx/sites-enabled/headscale` pointing at the same backend).
+
+Headscale itself never terminates TLS in this setup. Every client registration goes through Caddy.
+
+**Caddyfile (live):**
+
+```caddy
+{
+	admin localhost:2019
+	auto_https off
+}
+
+:443 {
+	tls /etc/letsencrypt/live/hs.lab.hole-truth.org/fullchain.pem /etc/letsencrypt/live/hs.lab.hole-truth.org/privkey.pem
+	reverse_proxy 127.0.0.1:8080 {
+		header_up X-Real-IP {remote_host}
+	}
+}
+```
+
+`admin localhost:2019` is required (not "off") because `caddy reload` uses the admin API. The admin endpoint is bound to loopback only.
+`auto_https off` is required because we provide the cert manually — without it Caddy would try to issue its own.
 
 ## Headscale config (key invariants)
 
@@ -110,11 +135,13 @@ Notes:
 
 ## Cert renewal
 
-`certbot` runs as a snap on `.77` with the `certbot-dns-cloudflare` plugin. Renewal uses DNS-01 against the `hole-truth.org` zone in Cloudflare. The Cloudflare API token is scoped to `Zone:DNS:Edit` + `Zone:Zone:Read` on `hole-truth.org` only.
+`certbot` runs as a snap on `.77` with the `certbot-dns-cloudflare` plugin. Renewal uses DNS-01 against the `hole-truth.org` zone in Cloudflare. The Cloudflare API token is scoped to `Zone:DNS:Edit` + `Zone:Zone:Read` on `hole-truth.org` only. Renewal cadence is the snap `snap.certbot.renew.timer` (~daily, late morning UTC).
 
-**Open security item**: the original Cloudflare API token was exposed in terminal output during initial setup. Treat it as compromised. The rotation is part of the cert handoff inside the Caddy-swap issue.
+On successful renewal, `/etc/letsencrypt/renewal-hooks/deploy/01-reload-caddy.sh` calls `systemctl reload caddy`. The cert files at `/etc/letsencrypt/live/hs.lab.hole-truth.org/{fullchain,privkey}.pem` are symlinks into `archive/`, so Caddy re-reading them picks up the new keypair without any file replacement on Caddy's side.
 
-`certbot renew --dry-run` succeeds today.
+`certbot renew --dry-run` succeeds.
+
+**Open security item**: the original Cloudflare API token was exposed in terminal output during initial setup. Treat it as compromised. The HOL-12 cert handoff chose the conservative path (keep certbot), so the token rotation was NOT done as part of that swap — it remains an outstanding item, tracked separately from the proxy change.
 
 ## Auth keys
 
@@ -133,7 +160,7 @@ For long-lived nodes (post-trial), each node gets its own one-time preauth key, 
 
 - The Headscale control-plane VM is administered exclusively over LAN SSH (`192.168.68.77`) and the Proxmox console — never via the tailnet. Losing the tailnet must not lose the control plane.
 - Every joined node retains LAN SSH reachability — public Tailscale and Headscale are both "extra" access paths, never the only one.
-- Proxmox snapshots are the cheap rollback. The existing `before-headscale-lab` snapshot on VM 112 + `pre-caddy-swap` (added by the Caddy-swap issue) cover the high-risk operations.
+- Proxmox snapshots are the cheap rollback. `before-headscale-lab`, `headscale-working`, and `pre-caddy-swap` exist on VM 112 covering the high-risk operations.
 - The `headscale users delete <user>` command will deregister every node owned by that user. Do not delete `lab` once production nodes are joined under it.
 
 ## Things this architecture does **not** do (today)

--- a/docs/homelab/headscale/cutover-playbook.md
+++ b/docs/homelab/headscale/cutover-playbook.md
@@ -1,0 +1,226 @@
+# Headscale cutover playbook
+
+This is the operator-facing procedure for moving one machine off public Tailscale onto self-hosted Headscale. Run it once per machine. Do not batch — every cutover is its own session with its own go-ahead, its own held-open SSH, and its own rollback rehearsal.
+
+If this is your first time, read [`architecture.md`](architecture.md) and [`rollback.md`](rollback.md) first. Read them cold. The cost is twenty minutes; the cost of skipping them and discovering the rollback procedure mid-cutover on a headless production machine is much higher.
+
+## Status of this playbook (read first)
+
+This playbook is **documentation-complete** as of 2026-06-04, but **not yet safe to run on virgin nodes**. Two prerequisites are open:
+
+1. **`.77` must be running Caddy, not nginx**, as the headscale control-plane TLS terminator. This is the swap that standardizes the reverse-proxy pattern across the network. See the "Swap nginx for Caddy on .77 …" issue in the project tracker. The trial nodes already on the mesh are unaffected; they continue to work through and after this swap. But virgin nodes joined while `.77` is still on nginx would inherit an inconsistent pattern that would have to be migrated later.
+2. **The cutover scripts (`bin/hs-preflight`, `bin/hs-cutover`, `bin/hs-rollback`) referenced below do not exist yet** — they ship in a follow-up PR. Until they do, the "scripted" steps below are run by hand from this document.
+
+Both prerequisites can land before the first production cutover. Neither blocks document review.
+
+## Section 1: Preconditions
+
+Before initiating a cutover on any machine, ALL of the following must be true. This is a checklist, not a recommendation.
+
+- [ ] **The target machine has a working LAN IP and you can SSH to it over that LAN IP** (not over the tailnet, not over a hostname that resolves through Tailscale DNS). Verify with `ssh user@192.168.68.x` from a workstation on the same LAN. If this fails, the cutover does not start — fix LAN reachability first.
+- [ ] **A second, independent SSH session over the LAN IP is open and held** in a separate terminal window. This is the escape hatch. If the primary session is interrupted, the secondary lets you run rollback without a console trip.
+- [ ] **The console of last resort is accessible** for this machine class:
+  - PVE VM: Proxmox web UI logged in, VM console window open in a third tab.
+  - PVE LXC: a shell on the PVE host so `pct enter <vmid>` is one command away.
+  - Bare-metal Mac: physical keyboard + monitor available within ~10 minutes (you can probably skip this for the lume VM and `mac-mini` since they have monitors attached; mandatory for any Mac without a screen).
+  - Bare-metal Linux: physical keyboard + monitor, or IPMI/iDRAC, or "I trust this LAN segment with a fallback Ethernet path".
+- [ ] **The previous machine in the cutover order is healthy on Headscale** and has been observed for at least 24 hours. No machine cuts over until the one before it has soaked.
+- [ ] **You have run the rollback drill on a disposable VM in the last 7 days.** Cold-reading the rollback document for the first time during a real cutover is the failure mode this rule prevents.
+- [ ] **`.77` is healthy.** `curl -s https://hs.lab.hole-truth.org/health` returns `{"status":"pass"}` from any joined node.
+- [ ] **A fresh, single-use preauth key has been generated** for the target user (`lab` today). Reusable keys are fine for the disposable trial; single-use is required for any production machine.
+
+If any of the boxes are unchecked, **stop**. Address the gap. Re-enter the playbook from the top when it's resolved.
+
+## Section 2: One control plane per node — the hard constraint
+
+A Tailscale client can register with exactly **one** control plane at a time. It cannot be on public Tailscale and Headscale simultaneously. There is no dual-homed mode and no transparent failover between control planes.
+
+The practical consequences:
+
+- **The cutover window has a real, observable gap.** Between `tailscale logout` (public) and the verification step on the new Headscale tailnet, this node is not on any tailnet. Target: less than 60 seconds. Maximum tolerable: 5 minutes (above which, abort and roll back).
+- **Any service that depends on the tailnet to be reachable will be unreachable during the gap.** This includes anything bound only to a tailnet IP, or anyone trying to SSH in via a tailnet hostname. The LAN-IP SSH session that you held open in section 1 is unaffected; it is the contract this playbook is built on.
+- **Other machines on public Tailscale lose this node from their peer list at logout.** Their next attempted connection to the cut-over node via tailnet will fail until that node rejoins (this time, on Headscale — different peer list).
+
+This is the irreducible cost. There is no playbook step that makes it go away. The playbook is designed around making the gap small, observed, and recoverable.
+
+## Section 3: The LAN SSH fallback contract
+
+For each machine, before any cutover step is run, the following must all be true:
+
+| Check | How to verify | What "passing" looks like |
+|-------|---------------|---------------------------|
+| LAN IP is reachable from your workstation | `ping -c 3 192.168.68.<n>` | 0% packet loss |
+| SSH on LAN IP works with key | `ssh -i <key> user@192.168.68.<n> 'whoami'` | returns the expected username |
+| The connection is over LAN, not tailnet | `ssh user@192.168.68.<n> 'who -m'` | shows your workstation's LAN address as the source, not a `100.x.x.x` |
+| Sudo works without prompting (or with a known password) | `ssh user@192.168.68.<n> 'sudo -n whoami'` | returns `root`, OR you have the password and can interact |
+
+If any of these fail, the playbook does not proceed for this machine. The single most common cutover failure mode is "I thought I had a LAN SSH path but it turned out my session was via a tailnet alias" — verify with `who -m`.
+
+The second SSH session held in a separate terminal window for the duration of the cutover MUST satisfy the same four checks, independently.
+
+## Section 4: Internal DNS for `hs.lab.hole-truth.org`
+
+The target machine must be able to resolve `hs.lab.hole-truth.org` to `192.168.68.77` before the cutover step. There are three options, in order of preference:
+
+### Short term — `/etc/hosts` entry
+
+This is what the trial nodes use today. The cutover script installs the line; if running by hand:
+
+```bash
+# On the target machine, in the LAN SSH session:
+if ! grep -q "hs.lab.hole-truth.org" /etc/hosts; then
+  echo "192.168.68.77 hs.lab.hole-truth.org" | sudo tee -a /etc/hosts
+fi
+# Verify:
+getent hosts hs.lab.hole-truth.org
+# Expected: 192.168.68.77   hs.lab.hole-truth.org
+```
+
+This survives reboot. It is brittle if `.77` ever moves to a different LAN IP — the cutover playbook deliberately does not own that scenario.
+
+### Medium term — internal DNS via `ddns` LXC
+
+When the `ddns` LXC at `.55` is configured to authoritatively serve `lab.hole-truth.org`, the `/etc/hosts` entry can be dropped. Joined nodes will resolve `hs.lab.hole-truth.org` through their normal DNS resolver chain (Headscale's MagicDNS hands them the LAN DNS server in `nameservers.global` — see [`architecture.md`](architecture.md)).
+
+This is the right end state for the LAN. Until it's live, the `/etc/hosts` line is the supported path.
+
+### Long term — split horizon
+
+Publish `hs.lab.hole-truth.org` in Cloudflare DNS pointing at the WAN IP, with a router-side TCP 443 forward to `192.168.68.77:443`. This enables off-LAN enrollment. Out of scope for the migration playbook; tracked separately.
+
+## Section 5: Per-OS join recipe
+
+The actual `tailscale up …` command and the surrounding state-clean is OS-specific. Follow the right per-OS document:
+
+- **[`per-os/linux-debian.md`](per-os/linux-debian.md)** — Debian, Ubuntu, anything systemd + apt
+- **[`per-os/linux-alpine.md`](per-os/linux-alpine.md)** — Alpine, anything OpenRC + apk
+- **[`per-os/macos-oss.md`](per-os/macos-oss.md)** — macOS running the open-source brew Tailscale build (recommended)
+- **[`per-os/macos-appstore.md`](per-os/macos-appstore.md)** — macOS running the App Store Tailscale (works, but harder)
+
+Every per-OS recipe ends with the same **verification block**, which is the contract for "did the join succeed":
+
+```bash
+# 1. Tailscale client reports healthy.
+tailscale status
+# Expected: shows "100.64.x.x  <hostname>  lab  <os> -" for self
+
+# 2. Tailnet IP assigned.
+tailscale ip -4
+# Expected: a "100.64.x.x" address
+
+# 3. MagicDNS round-trip for self.
+tailscale status --json | jq -r '.Self.DNSName'
+# Expected: <hostname>.tail.lab.hole-truth.org.
+
+# 4. Peer reachability — pick any other joined node and ping it.
+getent hosts linux-test-01
+# Expected: "100.64.0.1   linux-test-01.tail.lab.hole-truth.org"
+
+tailscale ping linux-test-01
+# Expected: a pong via direct or DERP — both fine
+```
+
+If any of these four fail, abort and proceed to [`rollback.md`](rollback.md). Do not skip ahead to "fix it forward" — the time spent troubleshooting forward almost always exceeds the time spent rolling back and trying again with a clear head.
+
+## Section 6: Reverse-proxy pattern (the real motivator)
+
+This section is about what you do *after* the cutover, when you actually want to run multiple HTTP services on a single Headscale-managed node. See [`reverse-proxy.md`](reverse-proxy.md) for the full Caddy reference; the short version:
+
+- Each service binds to a `127.0.0.1:<port>` on the node.
+- Caddy on the node binds to the node's tailnet IP on `:80` (stage 1) or `:443` (stage 2 / `tailscale cert`).
+- Caddy routes by `Host` header to the localhost port.
+- Other tailnet members hit `http://<hostname>/<path>` or `http://service-a.<hostname>/` (with a wildcard CNAME if you want subdomain-per-service) and Caddy demuxes.
+
+Stage 1 is HTTP-only over the tailnet because the WireGuard transport is already encrypted node-to-node. Stage 2 adds real LE-issued TLS certs via `tailscale cert` — a separate follow-up issue, not required for closing this migration.
+
+## Section 7: Per-machine cutover order
+
+Execute machines one at a time, in this order. Each cutover requires its own go-ahead from the owner (the user, for now) before it begins. Do not batch.
+
+1. **Lume macOS VM** (`Josephs-Virtual-Machine.local` at `192.168.64.2`).
+   This is the **experiment**, not a production cutover. The point is to capture every quirk of the macOS join path — both the fresh-install path (clean Headscale join) and the cutover path (install public Tailscale, join, then switch to Headscale). Every observation from this run becomes a note in `per-os/macos-oss.md` (or `per-os/macos-appstore.md`, depending on which build is exercised). No production machine is touched until this experiment is complete.
+
+2. **Alpine lab-controller** (`.74`, VM 107).
+   Currently offline. Power on, then run the Alpine recipe. Isolated host, very low blast radius. Empty of services.
+
+3. **Any newly-spun trial Linux VM** (e.g., `linux-test-03`).
+   Cheap to redeploy if something goes wrong. Useful for one more pass of the cutover playbook before touching production.
+
+4. **`mac-mini`** (secondary workstation, `192.168.68.68`).
+   First production cutover. Has a screen, has a wired Ethernet path, runs no daily-critical workloads. If the macOS path turns out to need adjustment, find that here, not on the Mac Studio.
+
+5. **`macbook-air`** (`192.168.68.70`, when not roaming).
+   Mobile, but uses LAN-attached at home. Cutover happens at home.
+
+6. **`my-vm` / `udev`** (`.66`, primary development VM on PVE).
+   Linux. Has services. Cutover happens during low-activity hours with the LAN SSH escape path open.
+
+7. **`mac-mini` again** if the secondary workstation slot has been re-used; otherwise skip.
+
+8. **Mac Studio LAST**. This is the workstation the operator cannot afford to lose. By the time we reach it, every other macOS host on the network is on Headscale and has been observed for at least 24 hours. The actual cutover follows the per-OS Mac recipe with extra paranoia: two held-open LAN SSH sessions (not one), the rollback script pre-positioned in a third terminal, and a window of attention reserved for at least 30 minutes after the cutover to confirm soak.
+
+## Section 8: Rollback drill — practice before production
+
+Before cutting over any production machine, run the cutover + rollback drill end to end on a disposable target (lume VM, fresh trial Linux VM, or one of the existing trial nodes). The drill is:
+
+1. Cut over the disposable machine to Headscale per the playbook.
+2. Verify it works (section 5 verification block).
+3. Wait 10 minutes.
+4. Pretend it's gone wrong. Follow [`rollback.md`](rollback.md) end to end. Time it.
+5. Verify the machine is back on the public tailnet.
+6. Time recorded must be < 5 minutes from "decide to roll back" to "verified back on public tailnet." If longer, find the slow step and fix it before the playbook touches anything real.
+7. (Optional) Cut it over to Headscale again. The point of the drill is that switching control planes is now a routine, low-stress operation for you.
+
+Drill at least once per quarter even after the migration is complete, so operator muscle memory does not atrophy.
+
+## Section 9: Cutover-day checklist (printable, ~20 lines)
+
+Print this. Cross items off in pen. Do not skip.
+
+```
+[ ] LAN SSH session to target (primary)         (terminal 1)
+[ ] LAN SSH session to target (escape hatch)    (terminal 2)
+[ ] Console-of-last-resort window open           (terminal 3 or PVE/UI)
+[ ] Rollback document open                      (browser or another window)
+[ ] Previous machine in order: healthy ≥ 24h    (verify in headscale nodes list)
+[ ] `.77` health check passes                    (curl /health → "pass")
+[ ] Single-use preauth key generated             (on .77 as headscale group)
+[ ] Auth key copied (not echoed in shared window)
+[ ] /etc/hosts entry for hs.lab.hole-truth.org present on target
+[ ] who -m on primary session: source IP is LAN, not tailnet
+[ ] Run per-OS recipe up through `tailscale up …`
+[ ] Verification block: tailscale status         (shows 100.64.x.x)
+[ ] Verification block: tailscale ip -4          (returns address)
+[ ] Verification block: tailscale ping <peer>    (pong)
+[ ] Verification block: getent hosts <peer>      (resolves)
+[ ] All four ✅                  → cutover successful, soak 30 min
+[ ] Any ✗                        → ROLLBACK (rollback.md)
+[ ] Mark machine in homelab inventory (architecture.md or homelab README)
+[ ] Notify (if anyone else uses this machine)
+```
+
+## Section 10: Post-cutover cleanup
+
+These are not blocking on the cutover succeeding — they are housekeeping done over the days after.
+
+- **Purge `tailscaled` cruft from the headscale host `.77`**. The control plane should not run a Tailscale client. `sudo apt purge tailscale && sudo rm -rf /var/lib/tailscale`. This was identified as a leftover from the original trial bring-up.
+- **Remove the `/etc/hosts` line** for `hs.lab.hole-truth.org` once internal DNS via `ddns` LXC is live. Verify with `getent hosts hs.lab.hole-truth.org` returning the same answer without the line present.
+- **Retire the public-Tailscale auth key** in Doppler once no machine on the network needs it for rollback anymore. Until then, keep it valid — it is the rollback path.
+- **Delete stale nodes** from the public Tailscale admin console for machines that have been cut over and confirmed soaked.
+- **Update [`architecture.md`](architecture.md)** — the host inventory table to reflect the new tailnet IPs for cut-over machines.
+- **Update `private_dot_ssh/config.tmpl`** in this repo if any SSH aliases point at public-tailnet hostnames that have changed. The LAN-IP fallback `Host` entries stay; tailnet aliases get the new addresses.
+
+## What this playbook deliberately does not cover
+
+- **Whole-network backup before cutover.** The risk model is per-machine, not per-network. Each cutover is independently rollback-able; there is no batch operation that warrants a whole-network snapshot. Per-machine Proxmox snapshots (for VMs) and Time Machine (for Macs) are the operator's choice — sufficient, not required.
+- **Automatic execution.** Nothing in this playbook is wired into `chezmoi apply`. The reasons are documented in [`README.md`](README.md): network identity changes are deliberate human acts.
+- **The macOS App Store TLS-cert quirks.** The `defaults write … ControlURL` path works for joining, but App Store builds have historically had inconsistent behavior around `tailscale cert`. Recommendation in [`per-os/macos-appstore.md`](per-os/macos-appstore.md) is to migrate to the open-source brew build for any Mac that needs per-node TLS.
+- **Subnet routing and ACL design.** Both are post-migration concerns. The migration ships an open-mesh policy and no advertised routes. Tightening happens after every machine is on Headscale.
+
+## Related
+
+- [`README.md`](README.md) — directory overview, current state, hard prerequisites
+- [`architecture.md`](architecture.md) — target end-state architecture
+- [`rollback.md`](rollback.md) — five-minute path back to public Tailscale
+- [`reverse-proxy.md`](reverse-proxy.md) — Caddy reference for multi-HTTP per node
+- [`per-os/`](per-os/) — OS-specific join recipes

--- a/docs/homelab/headscale/per-os/linux-alpine.md
+++ b/docs/homelab/headscale/per-os/linux-alpine.md
@@ -1,0 +1,102 @@
+# Cutover recipe — Alpine Linux
+
+The lab-controller at `.74` (VM 107) is the first Alpine target. As of 2026-06-04, that host is offline — this recipe is a sketch based on Alpine + Tailscale upstream conventions, **not yet exercised on a real host**. Update with measured values when the `.74` join happens.
+
+Read [`../cutover-playbook.md`](../cutover-playbook.md) first.
+
+## Differences from the Debian recipe
+
+| Concern | Debian | Alpine |
+|---------|--------|--------|
+| Init system | systemd | OpenRC |
+| Package manager | apt | apk |
+| Tailscale install path | `curl …/install.sh` | `apk add tailscale` |
+| Daemon service name | `tailscaled` (`systemctl`) | `tailscaled` (`rc-service` / `rc-update`) |
+| Service enable | `systemctl enable tailscaled` | `rc-update add tailscaled default` |
+| Log inspection | `journalctl -u tailscaled` | `tail -f /var/log/messages` (or `logread` on busybox) |
+
+Everything else — `/etc/hosts` requirement, preauth key, `tailscale up --login-server=…`, verification block — is identical.
+
+## Step 1: Install
+
+```bash
+# Update repo state if necessary
+sudo apk update
+
+# Install Tailscale from the community repo
+sudo apk add tailscale
+```
+
+If the community repo is not enabled, edit `/etc/apk/repositories` to uncomment the `community` line for your Alpine version, then re-run `apk update`.
+
+## Step 2: Enable and start the daemon
+
+```bash
+sudo rc-update add tailscaled default
+sudo rc-service tailscaled start
+
+# Wait for socket.
+for _ in 1 2 3 4 5; do
+  tailscale status &>/dev/null && break
+  sleep 1
+done
+
+tailscale status
+# Expected: "Logged out." (fresh install) or "..." if re-joining
+```
+
+## Step 3: Clear any prior state (cutover case)
+
+```bash
+sudo tailscale logout || true
+sudo tailscale down || true
+sudo rc-service tailscaled stop
+sudo rm -rf /var/lib/tailscale
+sudo rc-service tailscaled start
+```
+
+## Step 4: Verify reachability + join
+
+```bash
+# Reachability check (assumes /etc/hosts entry is already present per the playbook).
+getent hosts hs.lab.hole-truth.org
+curl -sf https://hs.lab.hole-truth.org/health
+
+# Join. Same flags as the Debian recipe.
+sudo tailscale up \
+  --login-server=https://hs.lab.hole-truth.org \
+  --authkey=<YOUR_PREAUTH_KEY> \
+  --hostname=<hostname> \
+  --accept-dns=true \
+  --accept-routes=true \
+  --reset
+```
+
+## Step 5: Verification block
+
+Same as the Debian recipe. See [`../cutover-playbook.md`](../cutover-playbook.md) §5.
+
+## Known Alpine gotchas (to verify on first real cutover)
+
+These are upstream-reported issues — confirm or refute when `.74` is actually cut over.
+
+- **`/dev/net/tun` permissions** may need a one-time `mknod` on minimal Alpine installs that omit the device. Check with `ls -la /dev/net/tun` — if missing, `sudo mkdir -p /dev/net && sudo mknod /dev/net/tun c 10 200 && sudo chmod 0666 /dev/net/tun`.
+- **`busybox`-based environments** sometimes lack `getent`. Use `nslookup hs.lab.hole-truth.org` or `cat /etc/hosts | grep hs.lab`.
+- **DNS resolution**: Alpine uses `musl libc`, which has historically had weaker DNS-resolver behavior than glibc. If `--accept-dns=true` does not produce working MagicDNS, fall back to running `tailscale set --accept-dns=false` and adding a manual `/etc/resolv.conf` entry for the MagicDNS IP from `tailscale status --json`.
+- **OpenRC service ordering**: if `tailscaled` starts before `net` is up, it may fail. Verify with `rc-status` post-boot. Add `rc_need="net"` to `/etc/conf.d/tailscaled` if so.
+
+## Status of this document
+
+**Skeleton, not yet validated.** Update each "to verify" item with concrete observed behavior the first time `.74` (or any other Alpine host) is cut over. Particular fields to fill in:
+
+- Actual `apk` repo line if the community repo had to be enabled.
+- Exact `rc-service` output on startup.
+- `tailscale version` reported on Alpine.
+- Anything `tailscale status --json | jq -r '.Self.DNSName'` returns (sanity-check the FQDN format).
+- Whether `--accept-dns=true` worked out of the box or needed the musl workaround.
+
+## Related
+
+- [`../cutover-playbook.md`](../cutover-playbook.md) — full procedure
+- [`../rollback.md`](../rollback.md) — rollback path
+- [`linux-debian.md`](linux-debian.md) — the well-trodden Debian/Ubuntu variant

--- a/docs/homelab/headscale/per-os/linux-debian.md
+++ b/docs/homelab/headscale/per-os/linux-debian.md
@@ -1,0 +1,153 @@
+# Cutover recipe — Linux (Debian / Ubuntu)
+
+The well-trodden path. This is what `linux-test-01` (Ubuntu, QEMU VM 108) and `linux-test-02` (Ubuntu LXC 102) actually did. systemd + apt.
+
+Read [`../cutover-playbook.md`](../cutover-playbook.md) first. This document covers only the OS-specific commands inside Section 5 (Per-OS join recipe). The preconditions, LAN-SSH-fallback contract, DNS prerequisite, and verification block all live there.
+
+## Prerequisites (assumed satisfied per the playbook)
+
+- Held-open LAN SSH session.
+- Console-of-last-resort available (Proxmox web UI VM console for VMs, `pct enter` host shell for LXCs).
+- `/etc/hosts` line present: `192.168.68.77 hs.lab.hole-truth.org`.
+- Single-use preauth key generated on `.77` and ready to paste.
+- For **LXC** targets only: the host-side LXC config has been edited and the container has been restarted with these three lines in `/etc/pve/lxc/<vmid>.conf`:
+  ```
+  features: nesting=1
+  lxc.cgroup2.devices.allow: c 10:200 rwm
+  lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file
+  ```
+  Without these, `tailscaled` falls back to slow userspace networking or fails to bring up `tailscale0` at all in unprivileged LXC. For QEMU VMs, none of this applies — Tailscale Just Works.
+
+## Step 1: Install the official Linux Tailscale package
+
+Skip this step if `dpkg -l tailscale` already shows it installed. Use the official package, not a snap or sideloaded build:
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+```
+
+The script auto-detects the distro and configures the appropriate apt repository under `/etc/apt/sources.list.d/`. Verify:
+
+```bash
+which -a tailscale
+# Expected: /usr/bin/tailscale (and possibly nothing else)
+
+/usr/bin/tailscale version
+systemctl is-active tailscaled
+# Expected: a 1.9x.x version; tailscaled = active
+```
+
+If `which -a tailscale` shows multiple binaries (Homebrew, snap, nix, etc.), the client/daemon version mismatch will bite you. Remove or path-shadow the non-official builds before continuing.
+
+## Step 2: Clear any prior Tailscale state
+
+If this is a fresh install, skip — `/var/lib/tailscale/` will be empty.
+
+If this node was on public Tailscale before (the typical cutover case), clear the cached state so the new control plane sees a clean enrollment:
+
+```bash
+sudo /usr/bin/tailscale logout || true
+sudo /usr/bin/tailscale down || true
+sudo systemctl stop tailscaled
+sudo rm -rf /var/lib/tailscale
+sudo systemctl start tailscaled
+
+# Wait for the daemon to come up.
+for _ in 1 2 3 4 5; do
+  /usr/bin/tailscale status &>/dev/null && break
+  sleep 1
+done
+
+# Verify daemon is up but unlogged.
+/usr/bin/tailscale status
+# Expected: "Logged out." or similar
+```
+
+This is the start of the "cutover window" — the node is off the previous tailnet at this point. The window closes after step 4 verifies. Target: under 60 seconds total.
+
+## Step 3: Confirm reachability to the control plane
+
+This catches DNS / TLS / firewall issues before they cause a confusing `tailscale up` hang:
+
+```bash
+getent hosts hs.lab.hole-truth.org
+# Expected: 192.168.68.77   hs.lab.hole-truth.org
+
+curl -sf https://hs.lab.hole-truth.org/health
+# Expected: {"status":"pass"}
+```
+
+If `getent` fails, the `/etc/hosts` line is missing. If `curl` fails with a TLS error, the cert is invalid or the reverse proxy isn't running. Either way, stop and fix before continuing.
+
+## Step 4: Join Headscale
+
+```bash
+# Replace <YOUR_PREAUTH_KEY> with the single-use key generated on .77.
+# Replace <hostname> with what this node should be called in MagicDNS — usually
+# the short hostname, e.g., "mac-mini" or "my-vm".
+
+sudo /usr/bin/tailscale up \
+  --login-server=https://hs.lab.hole-truth.org \
+  --authkey=<YOUR_PREAUTH_KEY> \
+  --hostname=<hostname> \
+  --accept-dns=true \
+  --accept-routes=true \
+  --reset
+```
+
+Notes on the flags:
+
+- `--login-server` is the critical one. Plain `sudo tailscale up` defaults to Tailscale Inc. and will silently take you back to the public tailnet — exactly the cutover-undo failure mode.
+- `--reset` ensures any leftover preference state from the previous tailnet is dropped, not merged.
+- `--accept-dns=true` enables MagicDNS resolution for `*.tail.lab.hole-truth.org`. Required for the verification block to pass.
+- `--accept-routes=true` is forward-looking — when the planned subnet router (`route-prox-01`) is added, this node will be ready to use routed LAN subnets without re-running `tailscale set`.
+- `--hostname` becomes the MagicDNS short name. Pick it carefully — changing it later requires removing and re-adding the node in headscale.
+
+## Step 5: Verification block (the contract)
+
+This is the same block as Section 5 of the playbook. Run all four:
+
+```bash
+# 1. Status.
+tailscale status
+# Expected: "100.64.x.x  <hostname>  lab  linux -" for self
+
+# 2. Tailnet IP assigned.
+tailscale ip -4
+# Expected: a 100.64.x.x address
+
+# 3. Self DNSName.
+tailscale status --json | jq -r '.Self.DNSName'
+# Expected: <hostname>.tail.lab.hole-truth.org.
+
+# 4. Peer reachability.
+getent hosts linux-test-01
+tailscale ping linux-test-01
+# Expected: address returned, pong via direct or DERP
+```
+
+If any of the four fail, **stop and [`rollback`](../rollback.md)**. Do not troubleshoot forward.
+
+## Step 6: Soak
+
+Watch this terminal for 10 minutes. The two failure modes to look for:
+
+- `tailscale status` flips to `Logged out` or shows a re-auth prompt — means the control plane rejected the session after initial accept. Logs:
+  ```bash
+  sudo journalctl -u tailscaled -n 50 --no-pager
+  ```
+- Peer ping fails after initially working — usually a DERP issue or a transient routing problem. Try again in 30 seconds; if it persists past 5 minutes, roll back.
+
+If both pass, the cutover is complete. Mark the machine off in the playbook checklist and update the host inventory in [`../architecture.md`](../architecture.md).
+
+## Known gotchas for Linux cutovers
+
+- **LXC nodes drop `tailscale0` on host reboot** unless the `lxc.cgroup2.devices.allow` line was persisted properly. After a host reboot, verify with `ip link show tailscale0` on every LXC.
+- **DERP-only connectivity** is normal between two LXC peers on the same Proxmox host because of how the bridge eats the direct-connect handshake. `tailscale ping` will report "via DERP" — that's fine, the throughput is acceptable, and direct connect resumes when one peer is on a different host.
+- **Ubuntu 24.04 with `systemd-resolved`** can ignore `--accept-dns=true` because resolved already owns `/etc/resolv.conf`. Check `resolvectl status` to see whether `tailscale0` is listed; if not, `sudo tailscale set --accept-dns=true` won't help and you need `resolvectl dns tailscale0 100.100.100.100` (or the actual MagicDNS service IP from `tailscale status --json`).
+
+## Related
+
+- [`../cutover-playbook.md`](../cutover-playbook.md) — full procedure
+- [`../rollback.md`](../rollback.md) — when this recipe fails
+- [`linux-alpine.md`](linux-alpine.md) — OpenRC-based Alpine variant

--- a/docs/homelab/headscale/per-os/macos-appstore.md
+++ b/docs/homelab/headscale/per-os/macos-appstore.md
@@ -1,0 +1,107 @@
+# Cutover recipe — macOS (App Store Tailscale build)
+
+The harder macOS path. The App Store build does not accept `--login-server` or `--authkey` flags — its login flow is OAuth via the menu-bar UI, and pointing it at Headscale requires setting a system-wide preference (`ControlURL`) before login. This works, but it's scriptable only with a click-the-menu-bar step in the middle, which makes it a poor fit for the cutover playbook's "scripted, observed, rollback-able" pattern.
+
+**Recommendation: migrate to the open-source brew build for any Mac that needs to be on Headscale.** See [`macos-oss.md`](macos-oss.md) for the open-source recipe; switching builds takes about ten minutes and removes most of the friction in this document.
+
+This document exists for the cases where the user has a hard requirement to stay on the App Store build (FileVault entanglement, MDM policy, etc.).
+
+## Status of this document
+
+**Skeleton.** The procedure below is based on Tailscale's published documentation and prior community reports, not on a tested cutover. Validate and refine when the first App Store cutover is exercised on the lume VM (or any disposable Mac).
+
+## The fundamental difference
+
+| Concern | Open-source brew build | App Store build |
+|---------|------------------------|-----------------|
+| Where the binary lives | `/opt/homebrew/bin/tailscale` (or `/usr/local/bin/...`) | `/Applications/Tailscale.app/Contents/MacOS/Tailscale` |
+| Daemon | `tailscaled` via `brew services` | Sandboxed system extension `io.tailscale.ipn.macsys` |
+| How you point it at Headscale | `--login-server=https://...` flag to `tailscale up` | `defaults write /Library/Preferences/io.tailscale.ipn.macos ControlURL <url>` before login |
+| Authentication | `--authkey=<preauth-key>` | Click menu-bar icon → "Log in" → OAuth flow in browser |
+| Scriptable? | Fully | Partially (the URL set is scriptable; the login click is not) |
+| Coexists with the other build? | **No** — they fight over `utun`. Choose one. |
+
+## Cutover steps
+
+### Step 1: Prerequisites
+
+Same as `macos-oss.md` Step 0 — held-open LAN SSH session, console plan, etc.
+
+In addition: **the user must be physically (or remotely) at the Mac to click "Log in" through the menu bar** at step 4. Pure SSH cutover is not possible with the App Store build.
+
+### Step 2: Add the `/etc/hosts` entry
+
+```bash
+if ! grep -q "hs.lab.hole-truth.org" /etc/hosts; then
+  echo "192.168.68.77 hs.lab.hole-truth.org" | sudo tee -a /etc/hosts
+fi
+dscacheutil -q host -a name hs.lab.hole-truth.org
+```
+
+### Step 3: Log out of the current tailnet
+
+In the menu bar: click the Tailscale icon → **Disconnect** → **Log out**.
+
+This is the start of the cutover window.
+
+### Step 4: Set the Headscale `ControlURL` preference
+
+```bash
+sudo defaults write /Library/Preferences/io.tailscale.ipn.macos ControlURL "https://hs.lab.hole-truth.org"
+
+# Verify.
+defaults read /Library/Preferences/io.tailscale.ipn.macos ControlURL
+# Expected: https://hs.lab.hole-truth.org
+```
+
+This tells the App Store build that the next login attempt should go to Headscale, not Tailscale Inc.
+
+### Step 5: Log in via the menu bar
+
+Click the Tailscale icon in the menu bar → **Log in**. This opens a browser tab pointing at `https://hs.lab.hole-truth.org/register/<key>` (or similar). The browser tab will show a Headscale registration prompt — typically a CLI command of the form:
+
+```
+headscale --user lab nodes register --key <node-key>
+```
+
+Run that command on `.77` (or have an agent / second person run it for you):
+
+```bash
+# On .77, as a user in the headscale group:
+headscale --user lab nodes register --key <node-key>
+```
+
+The browser tab will refresh and show "Success". The menu-bar Tailscale icon will turn green.
+
+If you have already generated a single-use preauth key for this machine, an alternative is:
+
+- Open `https://hs.lab.hole-truth.org/?preauth=<key>` directly from the browser instead of waiting for the menu-bar login.
+
+### Step 6: Verification block
+
+```bash
+# /Applications/Tailscale.app/Contents/MacOS/Tailscale is the CLI inside the App.
+# Some users symlink it to /usr/local/bin/tailscale for convenience.
+tailscale status
+tailscale ip -4
+tailscale status --json | jq -r '.Self.DNSName'
+dscacheutil -q host -a name linux-test-01
+tailscale ping linux-test-01
+```
+
+If the verification fails, [`rollback`](../rollback.md) — the App Store-specific path is documented there.
+
+## Known App Store gotchas
+
+To validate when this path is actually exercised:
+
+- **`defaults write` may need a Tailscale restart to take effect** (right-click menu bar icon → Quit, then re-open).
+- **`ControlURL` is read once at login**, not continuously. Changing it after login has no effect.
+- **The App Store build may not honor `--accept-routes`-style preferences** the same way the brew build does. Verify with `tailscale debug prefs`.
+- **`tailscale cert` from the App Store build** has historically been less reliable than from the brew build — another reason to prefer the brew build for any node that needs per-node TLS.
+
+## Related
+
+- [`macos-oss.md`](macos-oss.md) — the recommended macOS variant
+- [`../cutover-playbook.md`](../cutover-playbook.md) — full procedure
+- [`../rollback.md`](../rollback.md) — rollback (macOS App Store section)

--- a/docs/homelab/headscale/per-os/macos-oss.md
+++ b/docs/homelab/headscale/per-os/macos-oss.md
@@ -1,0 +1,180 @@
+# Cutover recipe — macOS (open-source brew build)
+
+The recommended macOS path. The open-source Tailscale build installed via Homebrew accepts the same `--login-server` and `--authkey` flags as the Linux client, which means `tailscale up` from a script Just Works. The App Store build requires the `defaults write … ControlURL …` workaround instead (see [`macos-appstore.md`](macos-appstore.md)); avoid it for any Mac that needs to be scripted.
+
+Read [`../cutover-playbook.md`](../cutover-playbook.md) first.
+
+## Measured baseline (lume macOS VM, 2026-06-04)
+
+The reachability and TLS-handshake assumptions in the playbook were verified empirically on the disposable lume VM. Pinning what was observed so the recipe below is grounded in reality, not assumed behavior.
+
+| Test | Result |
+|------|--------|
+| Guest macOS version | 26.5 (Tahoe), arm64 |
+| Default route from VM | gateway `192.168.64.1` (lume vmnet), via `en0` |
+| TCP `192.168.68.77:443` from inside VM | succeeds — lume's NAT'd vmnet allows outbound to LAN |
+| TLS handshake against `https://hs.lab.hole-truth.org` (with `--resolve` workaround) | succeeds — `CN=hs.lab.hole-truth.org`, valid until Sep 2026 |
+| `GET /health` response | `{"status":"pass"}` |
+| `/etc/hosts` entry for `hs.lab.hole-truth.org` | not present by default — must be added before join |
+| Tailscale pre-installed on the VM | no (`tailscale` CLI missing, no `/Applications/Tailscale.app`, no `ControlURL` pref) |
+
+Implication: the lume VM is a clean-slate environment. It exercises the **fresh-install path** for the macOS Headscale join, but not the **cutover path**. For the cutover-rehearsal use case (HOL-7), the experiment needs to install public Tailscale on the VM first, then switch to Headscale, then switch back as a rollback drill.
+
+## Step 0: Prerequisites
+
+Same as the playbook:
+- Held-open LAN SSH session to the Mac (over LAN IP, not tailnet alias).
+- For headless / remote Macs: console plan in place (physical screen, VNC, or for lume: `lume vnc` URL ready).
+- For the Mac Studio specifically: a **second** held-open LAN SSH session in a different terminal window. This machine is "cannot afford to lose"; spend the extra paranoia.
+
+## Step 1: Refuse to run alongside Tailscale.app (App Store build)
+
+The open-source brew build's `tailscaled` and the App Store `Tailscale.app`'s sandboxed system extension cannot coexist on the same Mac — they fight over the `utun` interface and produce a confusing version flap. If `Tailscale.app` is present, you have to remove it before installing the brew build:
+
+```bash
+# Check.
+ls -la /Applications/Tailscale.app 2>/dev/null && echo "App Store build present — must remove"
+systemextensionsctl list 2>/dev/null | grep "io.tailscale.ipn.macsys.*activated" && echo "System extension still active — must remove"
+
+# To remove (interactive, requires a reboot):
+sudo rm -rf /Applications/Tailscale.app
+# Then reboot the Mac to clear the activated system extension.
+# After reboot, verify:
+systemextensionsctl list 2>/dev/null | grep -c "io.tailscale.ipn.macsys.*activated"
+# Expected: 0
+```
+
+If `Tailscale.app` is present and the user wants to stay on the App Store build, **do not use this recipe** — go to [`macos-appstore.md`](macos-appstore.md).
+
+## Step 2: Install via Homebrew
+
+```bash
+# Install the formula (not the cask, which would install the App Store build).
+brew install tailscale
+
+# Start the daemon. On macOS, tailscaled must run as root to manage utun + DNS.
+sudo brew services start tailscale
+
+# Wait for the socket.
+for _ in 1 2 3 4 5; do
+  tailscale status &>/dev/null && break
+  sleep 1
+done
+
+# Verify.
+which -a tailscale
+# Expected: /opt/homebrew/bin/tailscale (Apple Silicon) or /usr/local/bin/tailscale (Intel)
+
+tailscale version
+# Expected: 1.9x.x
+```
+
+If `Tailscale.app` later somehow gets reinstalled (App Store auto-update, user clicks the cask), the brew build's daemon will silently fail with a version mismatch. This is the most common Mac-specific failure mode and the reason the cutover playbook recommends the brew build globally.
+
+## Step 3: Clear any prior Tailscale state (cutover case)
+
+If this Mac was on public Tailscale before (the typical case), wipe state:
+
+```bash
+sudo tailscale logout || true
+sudo tailscale down || true
+sudo brew services stop tailscale
+sudo rm -rf /Library/Tailscale       # client state
+sudo rm -rf /var/db/tailscale        # daemon state — path varies, safe to rm both if present
+sudo brew services start tailscale
+
+# Wait again.
+for _ in 1 2 3 4 5; do
+  tailscale status &>/dev/null && break
+  sleep 1
+done
+```
+
+The cutover window opens here. Target: less than 60 seconds to the verified state in step 6.
+
+## Step 4: Add the `/etc/hosts` entry
+
+macOS reads `/etc/hosts` before any DNS lookup, so this works the same as Linux:
+
+```bash
+if ! grep -q "hs.lab.hole-truth.org" /etc/hosts; then
+  echo "192.168.68.77 hs.lab.hole-truth.org" | sudo tee -a /etc/hosts
+fi
+
+# Verify.
+dscacheutil -q host -a name hs.lab.hole-truth.org
+# Expected: ip_address: 192.168.68.77
+# (dscacheutil is the macOS equivalent of getent — there is no getent on macOS by default)
+```
+
+## Step 5: Confirm reachability
+
+```bash
+nc -zv -G 5 192.168.68.77 443
+# Expected: Connection to 192.168.68.77 port 443 [tcp/https] succeeded!
+
+curl -sf https://hs.lab.hole-truth.org/health
+# Expected: {"status":"pass"}
+```
+
+If either fails, stop. The cutover window is open; either complete it quickly or roll back.
+
+## Step 6: Join Headscale
+
+```bash
+sudo tailscale up \
+  --login-server=https://hs.lab.hole-truth.org \
+  --authkey=<YOUR_PREAUTH_KEY> \
+  --hostname=<hostname> \
+  --accept-dns=true \
+  --accept-routes=true \
+  --reset
+```
+
+For `<hostname>`, prefer the short LocalHostName:
+
+```bash
+scutil --get LocalHostName
+# Use the output as --hostname value
+```
+
+This makes MagicDNS resolution consistent with the macOS Bonjour name the user is already used to (`<hostname>.local`).
+
+## Step 7: Verification block
+
+```bash
+# 1. Status.
+tailscale status
+
+# 2. Tailnet IP assigned.
+tailscale ip -4
+
+# 3. Self DNSName.
+tailscale status --json | jq -r '.Self.DNSName'
+
+# 4. Peer reachability.
+dscacheutil -q host -a name linux-test-01
+tailscale ping linux-test-01
+```
+
+If any of the four fail, [`rollback`](../rollback.md).
+
+## Step 8: Soak
+
+For a production Mac, watch for 30 minutes after the cutover succeeds. The macOS-specific failure modes to look for:
+
+- **`Tailscale.app` reinstalls itself** via App Store auto-update mid-soak. This will conflict with the brew daemon. Disable App Store auto-updates for Tailscale.app specifically, or uninstall the cask if present.
+- **`brew services` daemon dies after a system update.** macOS updates have historically reset some launch services. After any macOS update, verify with `sudo brew services list | grep tailscale`.
+- **DNS resolver scope.** macOS sometimes only applies the MagicDNS resolver for new connections. If a long-running app's connections are not resolving tailnet names, restart that app.
+
+## Known macOS gotchas
+
+- **`utun` interface number is non-deterministic.** `tailscale0` on Linux; `utunN` (where N is the next free number) on macOS. Don't hardcode the interface name in any script.
+- **System Integrity Protection** may block `tailscaled` from setting DNS unless the daemon is run by root via `brew services` (not as a user-launched LaunchAgent).
+- **The Mac Studio's daily-driver SSH key is in `~/.ssh/`** — if the cutover script ever needs to chmod or temporarily relocate `~/.ssh` (it shouldn't), be aware.
+
+## Related
+
+- [`../cutover-playbook.md`](../cutover-playbook.md) — full procedure
+- [`../rollback.md`](../rollback.md) — rollback path (macOS section)
+- [`macos-appstore.md`](macos-appstore.md) — App Store Tailscale build variant

--- a/docs/homelab/headscale/reverse-proxy.md
+++ b/docs/homelab/headscale/reverse-proxy.md
@@ -1,0 +1,175 @@
+# Reverse proxy — multiple HTTP services per Headscale node
+
+This is the operational pattern for the original reason the network is migrating to Headscale: **run multiple HTTP services on a single host behind one external endpoint**, using internal hostnames the tailnet already resolves. Public Tailscale's `serve` / `funnel` effectively caps a node at one HTTPS site without contortions; behind self-hosted Headscale, the answer is "run your own reverse proxy on the node, the way you would for any other Linux host."
+
+The reference reverse proxy across the hole-network is **Caddy**. The headscale control plane on `.77` will also be on Caddy once the swap issue ("Swap nginx for Caddy on .77 …") lands — same package, same config style, one pattern to learn.
+
+## Two stages
+
+| Stage | Transport | Why |
+|-------|-----------|-----|
+| **Stage 1 (today)** | HTTP over the tailnet | WireGuard encrypts node-to-node already. Inside the mesh, internal HTTP is fine and avoids the per-node cert-issuance dance. Anything outside the tailnet cannot reach these services. |
+| **Stage 2 (follow-up)** | HTTPS with `tailscale cert`-issued LE certs | Real, trusted TLS per node — useful when an external browser (via subnet router or future router-forwarded path) needs to hit a service. Requires the per-node cert automation, which is a separate issue, intentionally deferred. |
+
+This document covers stage 1 in full and stage 2 as a forward-looking appendix.
+
+## Stage 1: HTTP over the tailnet — single node, multiple services
+
+### Goal
+
+On a Headscale-joined node — let's say `linux-test-01` (`100.64.0.1`) — run three internal HTTP services:
+
+- `metabase` on `127.0.0.1:3000`
+- `grafana` on `127.0.0.1:3001`
+- `weaviate` on `127.0.0.1:8080`
+
+Other tailnet members should be able to hit:
+
+- `http://linux-test-01/metabase/...`
+- `http://linux-test-01/grafana/...`
+- `http://linux-test-01/weaviate/...`
+
+(Path-based routing, single host. Subdomain-based routing is also possible and is shown below as an alternative.)
+
+### Install Caddy
+
+```bash
+# Debian/Ubuntu
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update
+sudo apt install -y caddy
+```
+
+### `/etc/caddy/Caddyfile` — path-based routing
+
+```
+# Path-based: one host, services under /service-name/
+:80 {
+    # Anything under /metabase/ → metabase service.
+    handle_path /metabase/* {
+        reverse_proxy 127.0.0.1:3000
+    }
+
+    handle_path /grafana/* {
+        reverse_proxy 127.0.0.1:3001
+    }
+
+    handle_path /weaviate/* {
+        reverse_proxy 127.0.0.1:8080
+    }
+
+    handle {
+        respond "linux-test-01 — services: /metabase, /grafana, /weaviate" 200
+    }
+}
+```
+
+Apply and verify:
+
+```bash
+sudo caddy fmt --overwrite /etc/caddy/Caddyfile
+sudo caddy validate --config /etc/caddy/Caddyfile
+sudo systemctl reload caddy
+
+# From another tailnet member:
+curl http://linux-test-01/
+curl http://linux-test-01/metabase/
+```
+
+### `/etc/caddy/Caddyfile` — subdomain routing (alternative)
+
+Subdomain routing reads more naturally for human URLs and avoids the `/path/` prefix appearing in app links. Requires that the MagicDNS base domain works for the subdomain — `service-a.linux-test-01.tail.lab.hole-truth.org` will NOT resolve through MagicDNS by default, but you can add `extra_records` entries in `/etc/headscale/config.yaml` for each subdomain, OR use a wildcard configuration trick.
+
+The simpler (and recommended) form: use **distinct hostnames per service** rather than subdomains of one hostname. Put each service on its own Caddy node with its own MagicDNS hostname:
+
+```
+# On a node named "metabase" (100.64.0.5):
+:80 {
+    reverse_proxy 127.0.0.1:3000
+}
+```
+
+Then other tailnet members hit `http://metabase/` directly. This collapses the reverse-proxy + service into a 1:1 relationship per node and avoids the multi-service routing config entirely.
+
+**The multi-service-per-node pattern is the right tool when you have one beefy node and many small services. The one-service-per-node pattern is the right tool when each service is heavy enough to deserve isolation.** Pick deliberately; don't default to one or the other.
+
+### `caddy fmt` and `caddy validate`
+
+Caddy's `caddy fmt` rewrites the Caddyfile to canonical form (kills inconsistent indentation, reorders directives). `caddy validate` checks the syntax without applying it. Run both before every `systemctl reload caddy`:
+
+```bash
+sudo caddy fmt --overwrite /etc/caddy/Caddyfile
+sudo caddy validate --config /etc/caddy/Caddyfile
+sudo systemctl reload caddy
+```
+
+A reload (not restart) is non-disruptive — Caddy hot-swaps the running config without dropping connections. Reserve `systemctl restart caddy` for daemon updates.
+
+### Binding to tailnet IP only
+
+By default `:80` in a Caddyfile binds to ALL interfaces, including the LAN IP. If you only want the service reachable over the tailnet (LAN cannot reach it), bind to the tailnet IP explicitly:
+
+```
+# Discover with: tailscale ip -4
+100.64.0.1:80 {
+    ...
+}
+```
+
+This makes the reverse-proxy mesh-only. The LAN can still SSH to the node by LAN IP, but cannot reach the services. Useful for services you don't want a curious LAN device stumbling onto.
+
+### Logs
+
+Caddy logs to systemd by default. Tail with:
+
+```bash
+sudo journalctl -u caddy -f
+```
+
+Per-site access logs require an explicit `log` directive — see the [Caddyfile reference](https://caddyserver.com/docs/caddyfile/directives/log). For most internal services you don't need them.
+
+## Stage 2: HTTPS via `tailscale cert` (follow-on, separate issue)
+
+**Not implemented yet.** This is what the per-node TLS cert automation issue ("Per-node `tailscale cert` automation for multi-HTTP nodes") covers. Sketch of what it will look like:
+
+### Headscale-side prerequisite
+
+`tailscale cert <fqdn>` proxies an ACME request through the headscale control plane to Let's Encrypt. For this to work, two conditions must hold:
+
+- **The MagicDNS base domain (`tail.lab.hole-truth.org`) is publicly resolvable** so Let's Encrypt can complete the DNS-01 challenge. Today the zone is internal-only; this requires publishing it in Cloudflare (DNS-only, no proxy).
+- **Headscale config has the relevant `tls_letsencrypt_*` (or equivalent v0.28+) keys** set so the headscale server acts as the ACME proxy for its clients.
+
+Both conditions are part of the per-node-cert issue's scope.
+
+### Per-node `Caddyfile` with `tailscale cert`-issued cert
+
+Once issued via `tailscale cert <hostname>.tail.lab.hole-truth.org`, the cert files land in `/var/lib/tailscale/` (Linux) or `/Library/Tailscale/` (Mac). Caddy can point at them statically:
+
+```
+linux-test-01.tail.lab.hole-truth.org {
+    tls /var/lib/tailscale/certs/linux-test-01.tail.lab.hole-truth.org.crt \
+        /var/lib/tailscale/certs/linux-test-01.tail.lab.hole-truth.org.key
+
+    handle_path /metabase/* {
+        reverse_proxy 127.0.0.1:3000
+    }
+}
+```
+
+Renewal is via re-running `tailscale cert <fqdn>` (Caddy's auto-renewal does not work with non-public ACME). The follow-up issue provides a script + systemd-timer for automatic re-issuance.
+
+## Things this document deliberately doesn't cover
+
+- **External (off-tailnet) exposure.** Anything reachable from the public internet goes through a router-side port forward + Cloudflare DNS + (optionally) the existing public-edge nginx/Caddy on the WAN-facing host. The Headscale-internal reverse proxy is not the right layer for public exposure.
+- **WebSocket / HTTP/2 / gRPC pass-through.** Caddy handles all three by default. If a service has weird requirements, see the [Caddy reverse-proxy reference](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy).
+- **Load balancing across multiple backends.** Possible (`reverse_proxy backend-a:3000 backend-b:3000`), but the hole-network doesn't have a current need; tracked as out-of-scope.
+- **Authentication.** If a service needs auth in front of it, add it inside the `handle` block via Caddy's [`forward_auth`](https://caddyserver.com/docs/caddyfile/directives/forward_auth) or the upstream's own auth layer.
+
+## Related
+
+- [`architecture.md`](architecture.md) — the broader headscale architecture this fits into
+- [`cutover-playbook.md`](cutover-playbook.md) — playbook §6 references this document
+- The "Swap nginx for Caddy on .77" issue — control-plane consistency prerequisite
+- The "Per-node `tailscale cert` automation" issue — stage 2 prerequisite

--- a/docs/homelab/headscale/rollback.md
+++ b/docs/homelab/headscale/rollback.md
@@ -1,0 +1,157 @@
+# Rollback — back to public Tailscale
+
+This is the document you read **during** a cutover that has gone wrong. Read it once cold, before you run a cutover, so you know what's here. The whole point is to keep the worst case bounded: a Headscale join that fails leaves the node back on public Tailscale within five minutes.
+
+## When to roll back
+
+You should be on this page if any of the following happens during a cutover:
+
+1. **The Headscale join command hangs or errors out** and the verification steps in the per-OS recipe do not produce a `100.64.x.x` tailnet IP within ~2 minutes.
+2. **You join Headscale successfully, but the node can no longer reach a peer it could reach before** (LAN peers via LAN-IP still work; tailnet peers do not).
+3. **The held-open LAN SSH session is lost** — even if the cutover technically succeeded. Better to roll back, restore a known-good state, then redo the cutover with the safety net in place.
+4. **You feel uncertain.** The cost of rolling back and trying again is a few minutes. The cost of pushing through and locking yourself out of a headless machine is much higher.
+
+## What rollback actually does
+
+Rollback logs the node out of Headscale, removes the cached client state, and rejoins the **public** Tailscale tailnet (`lemming-likert.ts.net`) using the auth key stored in Doppler. After rollback, the node is exactly where it was before you started the cutover — same tailnet, same `100.x.x.x` address (assigned fresh, may differ), same peer list.
+
+It does NOT undo any other change you may have made on the node — Caddy config, `/etc/hosts` lines, firewall rules. Those have to be reverted by hand if they were touched.
+
+## Prerequisites you should already have
+
+All of these are part of the cutover preflight ([`cutover-playbook.md`](cutover-playbook.md) §3). If any are missing, the rollback can still happen but will require an extra manual step.
+
+- **A held-open SSH session over the LAN IP** of the node. Rollback runs in this session. If you lost it, console (Proxmox web UI for VMs; physical keyboard for bare metal) is the next path.
+- **The public Tailscale auth key** retrievable from Doppler scope `dotfiles/lxd-bootstrap`, secret name `TAILSCALE_AUTHKEY`. Doppler can be flaky over SSH — see "If Doppler can't reach the keyring" below.
+- **The original public-Tailscale node identity** is gone from the public tailnet (the cutover deliberately logged it out, which expires the node key after a grace period). Rollback creates a *new* node identity on the public tailnet. The previous node entry will need to be deleted in the Tailscale admin console after the dust settles — not blocking.
+
+## Linux rollback (Debian/Ubuntu/Alpine)
+
+Run all of this in the held-open LAN SSH session. Each command is idempotent.
+
+```bash
+# 1. Confirm you are on the machine you think you are.
+hostname
+ip -4 -br addr | head -5
+
+# 2. Log out of Headscale (no error if we're not on it).
+sudo tailscale logout || true
+
+# 3. Stop tailscaled and clear state.
+sudo systemctl stop tailscaled
+sudo rm -rf /var/lib/tailscale
+sudo systemctl start tailscaled
+sudo systemctl enable tailscaled
+
+# 4. Get the public Tailscale auth key from Doppler.
+#    On Linux this usually works fine. On macOS over SSH, see the macOS section.
+TS_AUTHKEY="$(doppler secrets get TAILSCALE_AUTHKEY --plain -p dotfiles -c lxd-bootstrap 2>/dev/null)"
+if [[ -z "$TS_AUTHKEY" ]]; then
+  echo "FATAL: could not retrieve auth key from Doppler. See 'If Doppler can't reach the keyring' below."
+  exit 1
+fi
+
+# 5. Join the public tailnet.
+sudo tailscale up \
+  --authkey="$TS_AUTHKEY" \
+  --hostname="$(hostname -s)" \
+  --reset
+
+# 6. Verify.
+tailscale status
+tailscale ip -4
+ping -c 3 100.94.84.6   # Mac Studio public-tailnet IP, change to any known peer
+```
+
+Expected: `tailscale ip -4` returns a `100.x.x.x` address in the `lemming-likert.ts.net` range, and you can ping a known peer.
+
+## macOS rollback (open-source brew build)
+
+Same shape as Linux but with macOS-specific paths.
+
+```bash
+# 1. Log out of Headscale.
+sudo tailscale logout || true
+
+# 2. Stop the daemon and clear state.
+sudo brew services stop tailscale
+sudo rm -rf /Library/Tailscale          # client state
+sudo rm -rf /var/db/tailscale           # daemon state (path varies by brew version)
+sudo brew services start tailscale
+
+# Give the daemon a moment to come up.
+for _ in 1 2 3 4 5; do
+  tailscale status &>/dev/null && break
+  sleep 1
+done
+
+# 3. Get the public Tailscale auth key.
+TS_AUTHKEY="$(doppler secrets get TAILSCALE_AUTHKEY --plain -p dotfiles -c lxd-bootstrap 2>/dev/null)"
+
+# 4. Join the public tailnet.
+sudo tailscale up \
+  --authkey="$TS_AUTHKEY" \
+  --hostname="$(scutil --get LocalHostName)" \
+  --reset
+
+# 5. Verify.
+tailscale status
+tailscale ip -4
+```
+
+## macOS rollback (App Store build)
+
+The App Store build does not accept `--authkey` and `--login-server` flags the way the open-source build does. Rolling back is a two-part operation:
+
+1. **Remove the Headscale ControlURL override.**
+
+   ```bash
+   sudo defaults delete /Library/Preferences/io.tailscale.ipn.macos ControlURL 2>/dev/null || true
+   # Or set explicitly to public:
+   sudo defaults write /Library/Preferences/io.tailscale.ipn.macos ControlURL "https://controlplane.tailscale.com"
+   ```
+
+2. **Log out and re-authenticate** through the Tailscale menu-bar UI:
+   - Click the Tailscale menu-bar icon → **Disconnect**.
+   - Click **Log out**.
+   - Click **Log in** — this opens the public Tailscale OAuth flow in a browser. Complete it.
+   - The node will appear in the public tailnet admin console under your account.
+
+The App Store rollback path is harder to script because it depends on the menu-bar UI. This is one reason the recommendation for production Macs is the open-source brew build.
+
+## If Doppler can't reach the keyring
+
+The most common Doppler-over-SSH failure mode on macOS is `dbus-launch: command not found` or `Could not connect to keyring`. The fallback is to retrieve the key from Doppler on a workstation that has GUI keyring access, then paste it into the rollback session:
+
+```bash
+# On a workstation (NOT on the locked-out node):
+doppler secrets get TAILSCALE_AUTHKEY --plain -p dotfiles -c lxd-bootstrap
+
+# Copy the output, then on the node (in the held-open SSH session):
+TS_AUTHKEY="tskey-auth-..."
+sudo tailscale up --authkey="$TS_AUTHKEY" --hostname="$(hostname -s)" --reset
+```
+
+For Linux nodes specifically, Doppler over SSH usually works because there's no keyring required for service-account tokens stored in `~/.config/doppler/`. If a Linux node fails to retrieve, run `doppler login` interactively in the SSH session first.
+
+## If the node is genuinely locked out
+
+If the held-open SSH session was lost AND the node is not reachable on its LAN IP either AND it's not on the tailnet, you are in console-recovery territory.
+
+- **PVE VM**: open the Proxmox web UI → VM → Console. You have keyboard + screen. Boot single-user mode if you need to bypass network-level lockout, then run the rollback commands from there. If filesystem is intact this is straightforward.
+- **PVE LXC**: `pct enter <vmid>` from a host shell (over the LAN-IP of `prox`). You're in as root with no SSH involved.
+- **Bare-metal Mac**: physical keyboard + screen. Boot into recovery mode if needed (`Cmd-R` at boot).
+- **Bare-metal Linux without console access**: this is the scenario the cutover playbook explicitly avoids by demanding console availability before starting on any headless machine. If you got here, the lesson is "do not skip the console-availability check next time."
+
+The single most valuable property of this setup is that **every machine in the hole-network is reachable by its LAN IP without any tailnet involvement**. As long as you can `ssh user@192.168.68.x` from a wired LAN connection, the rollback is alive.
+
+## Practicing rollback
+
+Before any production machine is touched, run the cutover + rollback drill on the lume macOS VM end to end. Time the rollback — if it takes more than five minutes from "decide to roll back" to "node is healthy on public tailnet", figure out what the slow step was and fix it before the playbook touches anything real.
+
+The disposable trial nodes (`linux-test-01`, `linux-test-02`) are also fine practice — they are already on Headscale, so the experiment is "log them out, rejoin public Tailscale, then log them back into Headscale". Each pass costs maybe 10 minutes and builds operator muscle memory.
+
+## Related
+
+- [`cutover-playbook.md`](cutover-playbook.md) — full procedure, where this file is referenced from
+- [`per-os/macos-oss.md`](per-os/macos-oss.md), [`per-os/macos-appstore.md`](per-os/macos-appstore.md) — per-OS specifics


### PR DESCRIPTION
### 
This pull request documents the migration of the homelab network from public Tailscale to a self-hosted Headscale instance. It introduces a new set of detailed documentation under `docs/homelab/headscale/`, outlining the migration process, architecture, operating procedures, and supporting materials. The main `README.md` is updated to reference this migration effort and the new documentation.

**Headscale migration documentation:**

* Added a new section to `docs/homelab/README.md` summarizing the Headscale migration and linking to the new documentation directory.
* Created `docs/homelab/headscale/README.md` as the entry point for the migration, explaining the rationale, current state, cutover order, and what is included/excluded from this documentation.

**Architecture and operational details:**

* Added `docs/homelab/headscale/architecture.md` describing the target end-state architecture after migration, including component maps, host inventory, DNS and naming conventions, control-plane TLS setup, Headscale configuration, cert renewal, authentication key management, lockout prevention strategies, and explicit non-goals.