### PR TITLE
feat(avahi): integrate Avahi/mDNS zero-config LAN discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,28 @@ jobs:
             echo "=== All tools verified ==="
           '
 
+      - name: Verify Avahi/mDNS configuration
+        run: |
+          docker run --rm --entrypoint /bin/bash dotfiles-test:ci -c '
+            echo "=== Checking Avahi / mDNS packages ==="
+            for pkg in avahi-daemon avahi-utils libnss-mdns; do
+              if dpkg -s "$pkg" >/dev/null 2>&1; then
+                echo "✓ $pkg installed"
+              else
+                echo "✗ $pkg MISSING" && exit 1
+              fi
+            done
+            echo "=== Checking nsswitch.conf for mdns4_minimal ==="
+            if grep -q "mdns4_minimal" /etc/nsswitch.conf; then
+              echo "✓ nsswitch.conf: $(grep "^hosts:" /etc/nsswitch.conf)"
+            else
+              echo "✗ nsswitch.conf missing mdns4_minimal"
+              echo "Current hosts line: $(grep "^hosts:" /etc/nsswitch.conf || echo "(none)")"
+              exit 1
+            fi
+            echo "=== Avahi/mDNS configuration verified ==="
+          '
+
       - name: Push to GHCR
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,14 @@ Cross-platform development environment managed by chezmoi.
 ```
 
 ### Script Execution Order
-1. `run_once_before_install-homebrew.sh.tmpl` — Install Homebrew
-2. `run_once_before_install-toolchains.sh.tmpl` — Tailscale + macOS dev tools
-3. chezmoi deploys all files (Brewfiles, configs, etc.)
-4. `run_once_after_install-brewfile.sh.tmpl` — `brew bundle` + Node + Claude Code
-5. `run_once_after_install-launchagent.sh.tmpl` — macOS auto-save agent
+1. `run_once_before_00-apt-bootstrap.sh.tmpl` — Linux apt prereqs (incl. Avahi packages)
+2. `run_once_before_install-homebrew.sh.tmpl` — Install Homebrew
+3. `run_once_before_install-tailscale.sh.tmpl` — Install Tailscale
+4. chezmoi deploys all files (Brewfiles, configs, etc.)
+5. `run_once_after_configure-avahi.sh.tmpl` — Configure mDNS/nsswitch.conf (Linux)
+6. `run_once_after_install-brewfile.sh.tmpl` — `brew bundle` + Node + Claude Code
+7. `run_once_after_install-launchagent.sh.tmpl` — macOS auto-save agent
+8. `run_once_after_install-tailscale-ssh.sh.tmpl` — Tailscale SSH setup
 
 ### Brewfile Strategy
 - `dot_Brewfile.core` — single cross-platform core (macOS + Linux)
@@ -46,6 +49,20 @@ Cross-platform development environment managed by chezmoi.
 - `dot_zshrc.tmpl` uses `{{ output "doppler" ... }}` to bake secrets at apply time
 - Guarded by `{{ if lookPath "doppler" }}` — skipped if Doppler isn't installed
 - Known issue: Doppler fails over SSH (keyring inaccessible) — see dotfiles#5
+
+## Network Discovery
+
+### Tailscale + MagicDNS (primary, all environments)
+- Installed via `run_once_before_install-tailscale.sh.tmpl` on macOS, bundled in Docker image
+- Provides secure WireGuard overlay on tailnet `lemming-likert.ts.net`
+- Use MagicDNS hostnames (`<hostname>.lemming-likert.ts.net`) for cross-machine access
+
+### Avahi / mDNS (LAN-local complement, Linux/real hosts)
+- Installed via `run_once_before_00-apt-bootstrap.sh.tmpl`: `avahi-daemon avahi-utils libnss-mdns`
+- Configured via `run_once_after_configure-avahi.sh.tmpl`: patches `/etc/nsswitch.conf` to add `mdns4_minimal [NOTFOUND=return]` before `dns`
+- Enabled at boot via systemd on real hosts/VMs; skipped silently in Docker build layers
+- macOS ships Bonjour natively — no install needed; `.local` resolution works out of the box
+- **Docker-bridge caveat**: containers on Docker's default bridge (`docker0`) cannot participate in LAN mDNS because multicast is not forwarded. Containers should use Tailscale MagicDNS for peer discovery. For LAN mDNS in a container, run with `--network=host`
 
 ## Docker Image
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repo owns **Layer 2**. For container stacks and infrastructure, see [hole-d
 | Editor configs (helix, kitty, btop, htop) | Yes | Yes | `dot_config/` |
 | Node LTS + Claude Code | Yes | Yes | `run_once_after_install-brewfile.sh.tmpl` |
 | Tailscale auto-join | — | Yes | `run_once_before_install-toolchains.sh.tmpl` |
+| Avahi / mDNS zero-config LAN discovery | Native (Bonjour) | Yes | `run_once_before_00-apt-bootstrap.sh.tmpl` |
 | Secrets via Doppler (baked at apply time) | Yes | Optional | `dot_zshrc.tmpl` |
 | Docker image (GHCR) | — | Pre-built | `Dockerfile.test` |
 
@@ -170,6 +171,19 @@ Installed via `dot_Brewfile.core` on Linux, included in the full `dot_Brewfile` 
 
 ---
 
+## Network Discovery
+
+Two complementary layers — Tailscale for secure overlay networking, Avahi for LAN-local zero-config discovery:
+
+| Layer | Technology | Scope | Resolves |
+|-------|------------|-------|---------|
+| Overlay | Tailscale + MagicDNS | All environments | `<host>.lemming-likert.ts.net` |
+| LAN | Avahi / Bonjour (mDNS) | Real hosts + VMs | `<host>.local` |
+
+**macOS**: Bonjour ships natively — `.local` resolution works automatically.  
+**Linux/VM**: `avahi-daemon` + `libnss-mdns` installed by bootstrap; `nsswitch.conf` patched to use `mdns4_minimal`.  
+**Docker containers**: mDNS multicast doesn't cross Docker's default bridge. Containers use Tailscale MagicDNS for peer discovery. Use `--network=host` if LAN mDNS is needed in a container.
+
 ## Tailscale Mesh
 
 All machines connected via tailnet `lemming-likert.ts.net`:
@@ -207,7 +221,7 @@ Every PR runs two jobs (both must pass to merge):
 
 | Job | What it tests |
 |-----|--------------|
-| **Linux** | Builds Docker image, verifies all core tools installed |
+| **Linux** | Builds Docker image, verifies all core tools installed, verifies Avahi packages + `nsswitch.conf` |
 | **macOS** | Runs `chezmoi apply`, verifies key files deploy and templates render |
 
 On merge to main: pushes updated image to `ghcr.io/jobikinobi/dotfiles:latest`.
@@ -239,10 +253,13 @@ dotfiles/
 │
 ├── private_dot_ssh/config.tmpl        # → ~/.ssh/config (OS-conditional)
 │
-├── run_once_before_install-homebrew.sh.tmpl    # 1. Install Homebrew
-├── run_once_before_install-toolchains.sh.tmpl  # 2. Tailscale + macOS toolchains
-├── run_once_after_install-brewfile.sh.tmpl     # 3. brew bundle + Node + Claude
-├── run_once_after_install-launchagent.sh.tmpl  # 4. macOS auto-save agent
+├── run_once_before_00-apt-bootstrap.sh.tmpl        # 1. Linux apt prereqs + Avahi packages
+├── run_once_before_install-homebrew.sh.tmpl        # 2. Install Homebrew
+├── run_once_before_install-tailscale.sh.tmpl       # 3. Install Tailscale
+├── run_once_after_configure-avahi.sh.tmpl          # 4. Configure mDNS/nsswitch.conf (Linux)
+├── run_once_after_install-brewfile.sh.tmpl         # 5. brew bundle + Node + Claude
+├── run_once_after_install-launchagent.sh.tmpl      # 6. macOS auto-save agent
+├── run_once_after_install-tailscale-ssh.sh.tmpl    # 7. Tailscale SSH setup
 │
 ├── Dockerfile.test                    # Ubuntu 24.04 dev node image
 ├── entrypoint.sh                      # Tailscale + sshd startup

--- a/run_once_after_configure-avahi.sh.tmpl
+++ b/run_once_after_configure-avahi.sh.tmpl
@@ -1,0 +1,66 @@
+{{- if ne .chezmoi.os "darwin" -}}
+#!/bin/bash
+# Configure Avahi/mDNS after packages are installed.
+#
+# What this does:
+#   1. Patches /etc/nsswitch.conf so glibc resolves .local names via mDNS
+#      before falling back to DNS (standard mdns4_minimal pattern).
+#   2. Enables and starts avahi-daemon via systemd where available.
+#      On containers / headless images without a live init system (e.g. Docker
+#      build layers), the daemon is left installed but not started — a startup
+#      service or `--network=host` run flag is needed for actual LAN discovery.
+#
+# Docker-bridge caveat: Docker's default bridge (docker0) does not forward
+# multicast packets, so avahi-daemon inside a bridge-networked container cannot
+# discover or advertise on the LAN. Avahi targets real hosts and VMs. Containers
+# that need peer discovery should use Tailscale MagicDNS instead (already
+# configured via run_once_before_install-tailscale.sh.tmpl).
+#
+# Idempotent: the nsswitch.conf patch is a no-op if already present.
+set -e
+
+if ! command -v avahi-daemon >/dev/null 2>&1; then
+  echo "→ avahi-daemon not found; skipping mDNS configuration"
+  exit 0
+fi
+
+# ── nsswitch.conf ──────────────────────────────────────────────────────────────
+# Insert mdns4_minimal before the dns entry so .local names are resolved via
+# mDNS without querying the DNS server (which would leak .local to upstream).
+# The [NOTFOUND=return] stops further lookup if mDNS explicitly says "no such
+# host", which avoids slow timeouts on LAN-only names.
+if grep -q "mdns4_minimal" /etc/nsswitch.conf 2>/dev/null; then
+  echo "→ nsswitch.conf already has mdns4_minimal — skipping"
+else
+  echo "→ Patching /etc/nsswitch.conf for mDNS resolution"
+  sudo sed -i \
+    's/^\(hosts:.*\b\)\(dns\b\)/\1mdns4_minimal [NOTFOUND=return] \2/' \
+    /etc/nsswitch.conf
+  # Verify the patch landed
+  if grep -q "mdns4_minimal" /etc/nsswitch.conf; then
+    echo "✓ nsswitch.conf updated: $(grep '^hosts:' /etc/nsswitch.conf)"
+  else
+    echo "⚠ sed pattern did not match; hosts line:"
+    grep '^hosts:' /etc/nsswitch.conf || echo "(no hosts line found)"
+  fi
+fi
+
+# ── avahi-daemon service ───────────────────────────────────────────────────────
+# Enable and start the daemon only when a live systemd instance is reachable.
+# In Docker build layers and other no-init environments, systemd is absent or
+# not running — skip silently rather than failing the bootstrap.
+if command -v systemctl >/dev/null 2>&1 \
+    && systemctl is-system-running --quiet 2>/dev/null; then
+  echo "→ Enabling avahi-daemon via systemd"
+  sudo systemctl enable avahi-daemon 2>/dev/null || true
+  sudo systemctl start  avahi-daemon 2>/dev/null || true
+  if systemctl is-active --quiet avahi-daemon; then
+    echo "✓ avahi-daemon running"
+  else
+    echo "⚠ avahi-daemon not active after start — check: journalctl -u avahi-daemon"
+  fi
+else
+  echo "→ systemd not active (container/headless build); avahi-daemon installed but not started"
+  echo "  On a real host run: sudo systemctl enable --now avahi-daemon"
+fi
+{{- end -}}

--- a/run_once_after_configure-avahi.sh.tmpl
+++ b/run_once_after_configure-avahi.sh.tmpl
@@ -33,8 +33,7 @@ if grep -q "mdns4_minimal" /etc/nsswitch.conf 2>/dev/null; then
   echo "→ nsswitch.conf already has mdns4_minimal — skipping"
 else
   echo "→ Patching /etc/nsswitch.conf for mDNS resolution"
-  sudo sed -i \
-    's/^\(hosts:.*\b\)\(dns\b\)/\1mdns4_minimal [NOTFOUND=return] \2/' \
+  sudo sed -i '/^hosts:/ s/ dns/ mdns4_minimal [NOTFOUND=return] dns/' \
     /etc/nsswitch.conf
   # Verify the patch landed
   if grep -q "mdns4_minimal" /etc/nsswitch.conf; then

--- a/run_once_before_00-apt-bootstrap.sh.tmpl
+++ b/run_once_before_00-apt-bootstrap.sh.tmpl
@@ -27,6 +27,10 @@ NEEDED_PACKAGES=(
   gnupg
   procps
   zsh
+  # mDNS / zero-config LAN discovery (Avahi stack)
+  avahi-daemon
+  avahi-utils
+  libnss-mdns
 )
 
 MISSING=()


### PR DESCRIPTION
## Summary

Integrates **Avahi / mDNS (`.local`) zero-config discovery** into the Linux dotfiles bootstrap, complementing existing Tailscale + MagicDNS overlay networking.

- Adds `avahi-daemon avahi-utils libnss-mdns` to the apt bootstrap — every Linux host gets them with no manual steps
- New `run_once_after_configure-avahi.sh.tmpl`: safety-net nsswitch.conf patch + systemd-guarded daemon enable; silently no-ops in Docker build layers
- CI gains "Verify Avahi/mDNS configuration" step (package install + nsswitch.conf checks)
- README and CLAUDE.md document the two-layer model, container caveat, and manual verification path

**macOS**: Bonjour ships natively — zero changes needed.  
**Containers**: Docker bridge doesn't forward mDNS multicast; containers use Tailscale MagicDNS. Avahi activates when run `--network=host` or on a real VM.

## Decisions made in-flight

| Question | Decision |
|----------|----------|
| Container mDNS | Document "bridge blocks multicast; use Tailscale" |
| Brewfile.core | Not touched — apt installs, not brew |
| macOS | No install; Bonjour is native |
| nsswitch.conf | Safety-net only; libnss-mdns postinst handles it on Ubuntu 24.04 |
| SSH service file (_ssh._tcp) | Deferred — core .local resolution lands first |

## Test plan

- [ ] CI passes: Linux Docker build + Avahi verify step green
- [ ] `dpkg -s avahi-daemon avahi-utils libnss-mdns` → installed in built image
- [ ] `grep "^hosts:" /etc/nsswitch.conf` → shows `mdns4_minimal [NOTFOUND=return]`
- [ ] Manual on Linux VM: `avahi-browse -tr _ssh._tcp` shows host; `getent hosts <hostname>.local` resolves

Closes HOL-286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)