### PR TITLE
fix(toolchains): retry brew supabase install on SIGPIPE (HOL-295)

### DIFF
--- a/run_once_after_install-toolchains.sh.tmpl
+++ b/run_once_after_install-toolchains.sh.tmpl
@@ -62,7 +62,24 @@ if command -v npm >/dev/null 2>&1; then
 fi
 
 # Supabase CLI via brew tap (not in core Brewfile because it needs a tap)
+# Homebrew intermittently emits "Error: Broken pipe" (SIGPIPE on its own stdout)
+# after a successful install, causing a non-zero exit that trips set -e.  Retry
+# up to 3 times and treat the install as successful if the binary lands in PATH,
+# even if brew's exit code was non-zero.
 if ! command -v supabase >/dev/null 2>&1 && command -v brew >/dev/null 2>&1; then
   echo "→ Installing Supabase CLI..."
-  brew install supabase/tap/supabase
+  _brew_ok=0
+  for _attempt in 1 2 3; do
+    if brew install supabase/tap/supabase; then
+      _brew_ok=1; break
+    fi
+    # Binary present despite non-zero exit → SIGPIPE on brew's output, not a
+    # real failure; consider it done.
+    if command -v supabase >/dev/null 2>&1; then
+      _brew_ok=1; break
+    fi
+    echo "  attempt $_attempt/3 failed, retrying in 5 s…"
+    sleep 5
+  done
+  [[ $_brew_ok -eq 1 ]] || { echo "ERROR: supabase install failed after 3 attempts" >&2; exit 1; }
 fi


### PR DESCRIPTION
## Summary

Fixes the flaky `profile / core` image build leg caused by Homebrew emitting `Error: Broken pipe` after a successful `supabase` install.

- **Root cause:** Homebrew gets SIGPIPE on its own stdout when the output reader closes early. The formula installs successfully (binary lands in PATH) but brew exits non-zero. `set -e` in the script then aborts the whole image build.
- **Fix:** Wrap `brew install supabase/tap/supabase` in a 3-attempt retry loop. After each non-zero exit, check if `supabase` is in PATH — if yes, it was a cosmetic SIGPIPE and we continue. If the binary is absent after 3 attempts, fail explicitly.
- **Scope:** `set -euo pipefail` is intentionally kept at the top (the Rust install pipeline needs pipefail); the fix is scoped to the supabase block only.

## Test plan

- [ ] CI `profile / core` Docker image build passes without a Broken pipe abort
- [ ] `supabase --version` exits 0 in the built image
- [ ] A simulated non-zero exit (binary present) short-circuits on attempt 1
- [ ] A genuine 3-failure scenario prints the ERROR message and exits 1

## Related

Fixes [HOL-295](/HOL/issues/HOL-295) — pre-existing flake first observed on PR #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)