### PR TITLE
feat(nix): scaffold flake with pinned inputs and profile stubs [HOL-506]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,3 +143,36 @@ jobs:
         run: |
           grep -q "1password" ~/.ssh/config && echo "✓ 1Password SSH agent in config"
           grep -q "/opt/homebrew" ~/.zshrc && echo "✓ Homebrew macOS path in zshrc"
+
+  # ── Nix flake check ─────────────────────────────────────────────────────────
+  # Validates nix/flake.nix syntax and evaluates all outputs.
+  # Runs on macOS so darwin configurations evaluate correctly.
+  # On first run (no nix/flake.lock yet), nix flake lock generates and commits
+  # the lockfile back to the PR branch before the check runs.
+  nix-flake-check:
+    name: nix flake check
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full ref so the auto-commit push targets the correct branch
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: DeterminateSystems/nix-installer-action@v14
+
+      - name: Lock flake inputs
+        run: nix flake lock ./nix
+
+      - name: Commit lockfile if generated
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: generate nix/flake.lock [skip ci]"
+          file_pattern: nix/flake.lock
+
+      - name: Check flake
+        # --no-build: evaluate all outputs without building derivations.
+        # Appropriate for P2 stubs; remove in P3/P4 once outputs produce packages.
+        run: nix flake check --no-build ./nix

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,0 +1,70 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782220169,
+        "narHash": "sha256-NxykfEdGQjop9m49Bk61pXpAduH8ICHgXC1N3Ph3Jp0=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "4b0b9474749820afac53ea30d4ccfef60aba5ce6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "HOLE Foundation dotfiles — Nix configurations";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    nix-darwin = {
+      url = "github:LnL7/nix-darwin/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, nix-darwin, home-manager, ... }: {
+
+    # macOS — Joe's personal machine (joe profile, P4)
+    darwinConfigurations."joes-macbook" = nix-darwin.lib.darwinSystem {
+      modules = [
+        ./profiles/common.nix
+        {
+          nixpkgs.hostPlatform = "aarch64-darwin";
+          system.stateVersion = 6;
+        }
+      ];
+    };
+
+    # macOS — headless agent node (agent profile, P3 / Q3 scope TBD)
+    darwinConfigurations."agent-mac" = nix-darwin.lib.darwinSystem {
+      modules = [
+        ./profiles/common.nix
+        {
+          nixpkgs.hostPlatform = "aarch64-darwin";
+          system.stateVersion = 6;
+        }
+      ];
+    };
+
+    # Linux — standalone home-manager for agent containers (agent profile, P3)
+    homeConfigurations."agent-linux" = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      modules = [
+        ./profiles/common.nix
+        {
+          home.username = "agent";
+          home.homeDirectory = "/home/agent";
+          home.stateVersion = "25.05";
+        }
+      ];
+    };
+
+  };
+}

--- a/nix/profiles/common.nix
+++ b/nix/profiles/common.nix
@@ -1,0 +1,4 @@
+# Shared profile stub.
+# P3 (agent) and P4 (joe) fill this in with actual packages and config.
+# See docs/conventions/workspace-directory-layout.md for workspace layout reference.
+{ ... }: {}

--- a/run_once_before_install-nix.sh.tmpl
+++ b/run_once_before_install-nix.sh.tmpl
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Install Nix via the Determinate Systems installer if not already present.
+# Docs: https://install.determinate.systems
+set -e
+
+if command -v nix &>/dev/null; then
+  echo "  ✓ nix already installed ($(nix --version))"
+  exit 0
+fi
+
+echo "→ Installing Nix (Determinate Systems)..."
+
+{{- if eq .chezmoi.os "darwin" }}
+# macOS: multi-user daemon required (SIP + sealed system volume)
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+  | sh -s -- install --no-confirm
+{{- else }}
+# Linux: daemon-less install for containers and VMs
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+  | sh -s -- install linux --no-confirm --init none
+{{- end }}
+
+echo "  ✓ Nix installed"


### PR DESCRIPTION
## Summary

- Adds `nix/flake.nix` with `nixpkgs-unstable` + `nix-darwin` + `home-manager` inputs and stub outputs: `darwinConfigurations` for `joes-macbook` + `agent-mac` (aarch64-darwin), `homeConfigurations` for `agent-linux` (x86_64-linux)
- Adds `nix/profiles/common.nix` — empty shared stub; P3 (agent) and P4 (joe) fill this in
- Adds `run_once_before_install-nix.sh.tmpl` — installs Nix via Determinate Systems installer if missing; multi-user on macOS, `--init none` on Linux
- Adds `nix-flake-check` CI job (macOS runner): installs Nix, locks inputs, auto-commits `nix/flake.lock`, runs `nix flake check --no-build`

## Lockfile note

`nix/flake.lock` is generated by the `nix-flake-check` CI job on first run (via `nix flake lock` + `stefanzweifel/git-auto-commit-action`). After CI generates and commits the lockfile, a second CI run confirms `nix flake check --no-build` is green.

## Test plan

- [ ] CI `nix-flake-check` job passes on macOS runner
- [ ] `nix/flake.lock` auto-committed to this branch by CI
- [ ] Second CI run (with lockfile present) also passes `nix flake check --no-build`
- [ ] Existing `linux` and `macos` jobs still pass (no regressions)

Closes HOL-506

🤖 Generated with [Claude Code](https://claude.com/claude-code)