### PR TITLE
feat(nix): joe profile — home-manager + nix-darwin macOS settings [HOL-508]

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -17,10 +17,12 @@
 
   outputs = { self, nixpkgs, nix-darwin, home-manager, ... }: {
 
-    # macOS — Joe's personal machine (joe profile, P4)
+    # macOS — Joe's personal machine (joe profile, P4 — HOL-508)
     darwinConfigurations."joes-macbook" = nix-darwin.lib.darwinSystem {
       modules = [
+        home-manager.darwinModules.home-manager
         ./profiles/common.nix
+        ./profiles/joe.nix
         {
           nixpkgs.hostPlatform = "aarch64-darwin";
           system.stateVersion = 6;

--- a/nix/profiles/joe.nix
+++ b/nix/profiles/joe.nix
@@ -1,0 +1,79 @@
+# Joe's personal profile — nix-darwin + home-manager (P4, HOL-508)
+#
+# Layer ownership (from HOL-499 ADR):
+#   - THIS FILE owns: tool versions (Nix-managed), macOS system settings
+#   - chezmoi owns: shell configs (.zshrc), secret injection
+#   - Doppler owns: all secrets
+#
+# home.file workspace dirs mirror docs/conventions/workspace-directory-layout.md.
+# The run_once_after_create-workspace-dirs.sh.tmpl creates the same dirs via
+# chezmoi; both are idempotent. Long-term (P5+) the script will be removed in
+# favour of this declarative source of truth.
+
+{ pkgs, ... }: {
+
+  # ── home-manager user settings ───────────────────────────────────────────
+  home-manager.useGlobalPkgs = true;
+  home-manager.useUserPackages = true;
+
+  home-manager.users.jth = { pkgs, ... }: {
+    home.username = "jth";
+    home.homeDirectory = "/Users/jth";
+    home.stateVersion = "25.05";
+
+    # Personal tools managed by Nix for version pinning.
+    # Only tools NOT already in dot_Brewfile.core or a project Brewfile.
+    # Homebrew continues to own the core CLI stack and casks.
+    home.packages = with pkgs; [
+      nil          # Nix language server (LSP for .nix files)
+      nixpkgs-fmt  # canonical Nix formatter (for nix/ in this repo)
+      mkcert       # local HTTPS dev certificates
+    ];
+
+    # Workspace directory stubs (see docs/conventions/workspace-directory-layout.md).
+    # home-manager creates parent dirs when symlinking these sentinel files.
+    home.file = {
+      "projects/gh/.keep".text  = "";
+      "projects/local/.keep".text = "";
+      "docs/notes/.keep".text     = "";
+      "docs/references/.keep".text = "";
+      "apps/.keep".text           = "";
+      "bin/.keep".text            = "";
+      "scratch/.keep".text        = "";
+    };
+  };
+
+  # ── nix-darwin system settings ────────────────────────────────────────────
+  system.defaults = {
+
+    dock = {
+      autohide                = true;
+      show-recents            = false;
+      minimize-to-application = true;
+      tilesize                = 48;
+    };
+
+    finder = {
+      AppleShowAllFiles       = true;   # show hidden files
+      ShowPathbar             = true;
+      ShowStatusBar           = true;
+      FXPreferredViewStyle    = "Nlsv"; # list view default
+      _FXShowPosixPathInTitle = true;
+      FXEnableExtensionChangeWarning = false;
+    };
+
+    NSGlobalDomain = {
+      # Key repeat — essential for vim/helix; disables press-and-hold accent picker
+      ApplePressAndHoldEnabled = false;
+      KeyRepeat                = 2;
+      InitialKeyRepeat         = 15;
+
+      # Scroll / gesture
+      "com.apple.swipescrolldirection" = false; # disable natural scrolling
+    };
+
+    trackpad = {
+      Clicking = true; # tap to click
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Creates `nix/profiles/joe.nix` — P4 deliverable (HOL-508)
- Updates `nix/flake.nix` to wire `home-manager.darwinModules.home-manager` and `./profiles/joe.nix` into `darwinConfigurations."joes-macbook"`

## What's in joe.nix

**home-manager user config (jth):**
- `home.packages`: `nil` (Nix LSP), `nixpkgs-fmt` (formatter), `mkcert` (local HTTPS) — Nix-pinned tools not already in `dot_Brewfile.core`
- `home.file` workspace directory stubs: `projects/gh/`, `projects/local/`, `docs/notes/`, `docs/references/`, `apps/`, `bin/`, `scratch/` — mirrors [HOL-505](https://github.com/Jobikinobi/dotfiles/pull/75) layout declaration

**nix-darwin system.defaults:**
- Dock: autohide on, no recents, minimize-to-application, tile size 48
- Finder: show hidden files, path bar, status bar, list view, POSIX path in title, no extension-change warning
- NSGlobalDomain: key repeat enabled (press-and-hold off, repeat=2, initial=15), natural scrolling off
- Trackpad: tap to click

## Layer ownership (HOL-499)

| Layer | Owns |
|---|---|
| `joe.nix` | Tool versions (Nix-pinned), macOS system settings |
| chezmoi | Shell configs (`.zshrc`), secret injection |
| Doppler | All secrets |

## Workspace dir overlap note

`run_once_after_create-workspace-dirs.sh.tmpl` (HOL-505) already creates the same directories. Both are idempotent — no conflict. The run-once script will be removed in P5 ([HOL-509](https://github.com/Jobikinobi/dotfiles/issues)) once bootstrap wiring lands.

## Verification required ⚠️

**Nix is not installed in the agent environment.** Joe must verify on his MacBook:

```bash
# Safe (build only, no activation):
darwin-rebuild build --flake ~/path/to/dotfiles/nix#joes-macbook

# Full activation (activates dock/finder/key-repeat settings):
darwin-rebuild switch --flake ~/path/to/dotfiles/nix#joes-macbook
```

The agent cannot run `darwin-rebuild switch` — it mutates macOS system-level state (sudo required, irreversible until manually switched back).

## Checklist

- [x] `nix/profiles/joe.nix` committed
- [x] `nix/flake.nix` updated — `joes-macbook` wires home-manager + joe.nix
- [ ] `darwin-rebuild build --flake .#joes-macbook` passes (Joe to verify)
- [ ] `darwin-rebuild switch --flake .#joes-macbook` passes (Joe to activate)
- [ ] PR merged to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)