### PR TITLE
feat(nix): implement agent home-manager profile [HOL-507]

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -44,6 +44,7 @@
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
       modules = [
         ./profiles/common.nix
+        ./profiles/agent.nix
         {
           home.username = "agent";
           home.homeDirectory = "/home/agent";

--- a/nix/profiles/agent.nix
+++ b/nix/profiles/agent.nix
@@ -1,0 +1,59 @@
+{ config, pkgs, lib, ... }:
+
+# Headless profile for Paperclip/agent machines.
+#
+# Platform-agnostic: works under home-manager.lib.homeManagerConfiguration (Linux)
+# and nix-darwin.darwinModules.home-manager (macOS) — but macOS agent-mac is gated
+# on Q3 board resolution; for now only agent-linux uses this module.
+#
+# home.username / homeDirectory / stateVersion are set per-host in flake.nix.
+# Secrets are NOT managed here — they stay in Doppler per ADR-001.
+{
+  home.packages = with pkgs; [
+    # VCS and GitHub integration
+    git
+    gh
+
+    # HTTP and data
+    curl
+    jq
+
+    # Filesystem search (agents grep and navigate codebases)
+    ripgrep
+    fd
+
+    # Agent runtimes
+    nodejs_22  # Paperclip harness + TypeScript tooling
+    python3    # agent scripts, ML pipeline helpers
+
+    # Headless session management
+    tmux
+
+    # Commit signing
+    gnupg
+  ];
+
+  programs.git = {
+    enable = true;
+    # name/email unset — operators set these per-deployment via git config or env.
+    extraConfig = {
+      init.defaultBranch = "main";
+      pull.rebase = true;
+    };
+  };
+
+  # Workspace directory layout from docs/conventions/workspace-directory-layout.md.
+  # Uses home.activation (not home.file) because home.file creates files, not empty
+  # directories — activation is the correct home-manager idiom for this.
+  # Mirrors run_once_after_create-workspace-dirs.sh.tmpl for parity.
+  home.activation.createWorkspaceDirs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD mkdir -p \
+      "${config.home.homeDirectory}/projects/gh" \
+      "${config.home.homeDirectory}/projects/local" \
+      "${config.home.homeDirectory}/docs/notes" \
+      "${config.home.homeDirectory}/docs/references" \
+      "${config.home.homeDirectory}/apps" \
+      "${config.home.homeDirectory}/bin" \
+      "${config.home.homeDirectory}/scratch"
+  '';
+}


### PR DESCRIPTION
## Summary

- **`nix/profiles/agent.nix`** — new home-manager module for Paperclip/agent machines. Platform-agnostic (targets both `home-manager.lib.homeManagerConfiguration` on Linux and `nix-darwin.darwinModules.home-manager` on macOS when Q3 resolves).
- **`nix/flake.nix`** — wires `agent.nix` into `homeConfigurations."agent-linux"`; `darwinConfigurations."agent-mac"` left on `common.nix` stub (no `home-manager.darwinModules` wired + Q3 pending).

### agent.nix contents

| Section | What it does |
|---|---|
| `home.packages` | git, gh, curl, jq, ripgrep, fd, nodejs_22, python3, tmux, gnupg |
| `programs.git` | `defaultBranch=main`, `pull.rebase=true`; name/email unset (set per-deployment) |
| `home.activation.createWorkspaceDirs` | Idempotent `mkdir -p` for the canonical workspace layout (see `docs/conventions/workspace-directory-layout.md`) |

**Note on `home.file` vs `home.activation`:** The issue spec says "`home.file` entries" for workspace dirs. `home.file` creates managed files, not empty directories — `home.activation` is the correct home-manager idiom. Calling out the deviation here deliberately.

**Secrets:** nothing secret in this module. Doppler remains the only secret store per ADR-001.

**`darwinConfigurations."agent-mac"`:** intentionally untouched. Adding `agent.nix` there would cause eval errors (`home.*` options don't exist in a bare nix-darwin config without `home-manager.darwinModules.home-manager` wired). macOS agent machines are also gated on Q3 board resolution.

## Verification status

| Step | Status |
|---|---|
| `nix flake check --no-build ./nix` (CI, macOS runner) | ⏳ pending CI run |
| `home-manager switch --flake .#agent-linux` in LXD container | ⚠️ blocked — no x86_64-linux builder or LXD test container in this environment |

The LXD activation step (Done criteria) requires a Linux build environment. This PR can merge once CI is green; the LXD step is tracked as a follow-on blocker in HOL-507.

## Test plan

- [ ] CI `nix-flake-check` job passes (macOS, evaluation-only)
- [ ] Review `agent.nix` package list for any unfree / unavailable nixpkgs-unstable packages
- [ ] LXD activation: `home-manager switch --flake .#agent-linux` on a fresh Ubuntu 24.04 LXD container (post-merge, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)