### PR TITLE
fix(ci): remove Supabase CLI, fix nix-darwin primaryUser and git.settings, repair oversight profile build

### DIFF
--- a/nix/profiles/joe.nix
+++ b/nix/profiles/joe.nix
@@ -12,6 +12,8 @@
 
 { pkgs, ... }: {
 
+  system.primaryUser = "jth";
+
   users.users.jth.home = "/Users/jth";
 
   # ── home-manager user settings ───────────────────────────────────────────

--- a/run_once_after_install-toolchains.sh.tmpl
+++ b/run_once_after_install-toolchains.sh.tmpl
@@ -61,8 +61,3 @@ if command -v npm >/dev/null 2>&1; then
   done
 fi
 
-# Supabase CLI via brew tap (not in core Brewfile because it needs a tap)
-if ! command -v supabase >/dev/null 2>&1 && command -v brew >/dev/null 2>&1; then
-  echo "→ Installing Supabase CLI..."
-  brew install supabase/tap/supabase
-fi


### PR DESCRIPTION
Fixes three separate CI failures that were blocking the `CI / linux` required status check.

## Changes Made

### 1. Remove Supabase CLI from toolchain bootstrap
Removed the `brew install supabase/tap/supabase` block from `run_once_after_install-toolchains.sh.tmpl`. Supabase CLI is no longer needed as a managed toolchain dependency.

### 2. Fix `nix flake check` — `system.primaryUser` (nix-darwin upgrade)
Added `system.primaryUser = "jth"` to `nix/profiles/joe.nix`. Updated nix-darwin now requires this to be set whenever `system.defaults.*` options (dock, finder, NSGlobalDomain, trackpad) are used, as all system activation now runs as root and these options apply to the designated primary user.

### 3. Fix `nix flake check` — `programs.git.settings` rename (home-manager upgrade)
Renamed `programs.git.extraConfig` → `programs.git.settings` in `nix/profiles/agent.nix`. The home-manager option was renamed upstream; the old name is no longer accepted.

### 4. Fix `profile / oversight` Docker build — pre-warmed image cache
Added an early-return guard to `build_image()` in `scripts/test-profile.sh`: if the image already exists in the local Docker daemon (loaded by the CI pre-warm step via BuildKit + GHA remote cache), the function skips the `docker build` entirely and reuses the pre-built image. Without this guard, the default builder rebuilds from scratch on a cold local cache, triggers a fresh Homebrew install, and hits a broken perl 5.42.2 bottle (`tar: perl/5.42.2/share/man: Cannot mkdir`). Passing `--no-cache` bypasses the guard and forces a full rebuild as before.