### PR TITLE
feat(nix): wire nix_profile selection into chezmoi bootstrap (HOL-509)

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -21,10 +21,12 @@ encryption = "age"
 {{- end }}
     projects = {{ $project_list | toJson }}
     lxd_profile = {{ promptStringOnce . "lxd_profile" "LXD profile key (blank for none)" "" | quote }}
+    nix_profile = {{ promptStringOnce . "nix_profile" "Workspace profile [joe/agent] (blank for no Nix)" "" | quote }}
 {{- else }}
     name = "Joseph T. Herrmann, M.D."
     email = "joeherrmann@gmail.com"
     github_user = "Jobikinobi"
     projects = []
     lxd_profile = ""
+    nix_profile = ""
 {{- end }}

--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -88,10 +88,11 @@ Add a chezmoi profile for the newly created Paperclip project `<project-name>`. 
 
 ## Data variables
 
-The profile system reads two variables from `~/.config/chezmoi/chezmoi.toml` (rendered from `.chezmoi.toml.tmpl`):
+The profile system reads three variables from `~/.config/chezmoi/chezmoi.toml` (rendered from `.chezmoi.toml.tmpl`):
 
 - `projects` — list of active profile keys for this machine. Example: `projects = ["legal", "godocs"]`. Empty list `[]` means "core only". Multiple profiles compose freely.
 - `lxd_profile` — single scalar naming the LXD profile when this machine was provisioned as a container (e.g. `lxd_profile = "legal"`). Empty string on laptops. Used by host-side tooling, not by chezmoi itself.
+- `nix_profile` — Nix workspace profile to activate on this machine. Valid values: `joe` (personal Mac, maps to `darwinConfigurations."joes-macbook"` or `homeConfigurations."joe-linux"`) and `agent` (headless agent node, maps to `darwinConfigurations."agent-mac"` or `homeConfigurations."agent-linux"`). Empty string means "no Nix activation" — Nix will not be installed or activated on this machine.
 
 In templates, gate per-project work with the existing `has` idiom:
 
@@ -99,7 +100,7 @@ In templates, gate per-project work with the existing `has` idiom:
 {{- if not (has "legal" .projects) }}exit 0{{ end }}
 ```
 
-The interactive `chezmoi init` path prompts for both; the non-interactive (cloud-init pre-seed) path expects the values to be written into `~/.config/chezmoi/chezmoi.toml` before `chezmoi init` runs. Defaults are `projects = []` and `lxd_profile = ""` — a fresh machine with no answers does nothing project-specific.
+The interactive `chezmoi init` path prompts for all three; the non-interactive (cloud-init pre-seed) path expects the values to be written into `~/.config/chezmoi/chezmoi.toml` before `chezmoi init` runs. Defaults are `projects = []`, `lxd_profile = ""`, and `nix_profile = ""` — a fresh machine with no answers does nothing project-specific.
 
 ## How it works
 
@@ -185,14 +186,21 @@ scripts/provision-lxd.sh --project legal --name the-legal-01 --dry-run
 
 # launch for real (requires doppler login + tailnet reachability)
 scripts/provision-lxd.sh --project legal --name the-legal-01
+
+# launch with Nix profile activation (seeds nix_profile in the pre-seeded chezmoi.toml)
+scripts/provision-lxd.sh --project legal --name the-legal-01 --nix-profile agent --dry-run
+scripts/provision-lxd.sh --project legal --name the-legal-01 --nix-profile agent
 ```
 
 The script:
 
 - validates `<key>` against `dot_Brewfile.<key>` so typos fail fast,
+- validates `--nix-profile` against known flake outputs (`joe`, `agent`) when supplied,
 - fetches a **single-use, ephemeral** Tailscale auth key from Doppler scope `dotfiles/lxd-bootstrap` (secret `TAILSCALE_AUTHKEY`),
-- renders a cloud-init that pre-seeds `~/.config/chezmoi/chezmoi.toml` with `projects = ["<key>"]` + `lxd_profile = "<key>"` and runs `chezmoi init --apply jobikinobi`,
+- renders a cloud-init that pre-seeds `~/.config/chezmoi/chezmoi.toml` with `projects = ["<key>"]` + `lxd_profile = "<key>"` + `nix_profile = "<profile>"` and runs `chezmoi init --apply jobikinobi`,
 - SSHes to the Proxmox host (default `proxmox.lemming-likert.ts.net`; override with `--host` or `$LXD_PROXMOX_HOST`) and runs `lxc init` / `lxc config set user.user-data` / `lxc start` — the user-data is streamed over stdin so the auth key never lands in remote `ps` output.
+
+**Known limitation — `--nix-profile agent` on LXD:** The container user is `jth`, but `homeConfigurations."agent-linux"` in the flake pins `home.username = "agent"` and `home.homeDirectory = "/home/agent"`. home-manager standalone will refuse to activate due to the username mismatch. End-to-end verification of `--nix-profile agent` on an LXD container is tracked as HOL-510.
 
 The age decryption key (`~/.config/chezmoi/key.txt`) is intentionally **not** baked into cloud-init. Provision it out-of-band after the container is reachable on the tailnet if the dotfiles include encrypted files you need on that host. See [THE-68](/THE/issues/THE-68) for the design notes.
 

--- a/run_once_after_nix-profile.sh.tmpl
+++ b/run_once_after_nix-profile.sh.tmpl
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Activate the Nix workspace profile selected via chezmoi.toml data.nix_profile.
+# Runs after chezmoi deploys source files so the flake under
+# {{ .chezmoi.sourceDir }}/nix/ is present before activation begins.
+set -euo pipefail
+
+{{- if not (index . "nix_profile") }}
+exit 0
+{{- end }}
+
+FLAKE="{{ .chezmoi.sourceDir }}/nix"
+PROFILE="{{ index . "nix_profile" | default "" }}"
+
+# Source the Nix daemon profile to put nix on PATH in this subprocess.
+# Required because run_once_after scripts run in a plain bash context that
+# has not sourced the user's shell init files.
+NIX_DAEMON_PROFILE="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+if [ -f "$NIX_DAEMON_PROFILE" ]; then
+  # shellcheck source=/dev/null
+  . "$NIX_DAEMON_PROFILE"
+fi
+
+# Safety-net install: run_once_before_install-nix.sh.tmpl handles first-time
+# installs, but a forced re-apply on a machine where Nix was removed manually
+# will not re-run the before script (it is already in the run_once journal).
+if ! command -v nix &>/dev/null; then
+  echo "→ Nix not on PATH; installing via Determinate Systems..."
+{{- if eq .chezmoi.os "darwin" }}
+  curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+    | sh -s -- install --no-confirm
+{{- else }}
+  curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+    | sh -s -- install linux --no-confirm --init none
+{{- end }}
+  if [ -f "$NIX_DAEMON_PROFILE" ]; then
+    # shellcheck source=/dev/null
+    . "$NIX_DAEMON_PROFILE"
+  fi
+fi
+
+echo "→ Activating Nix profile: $PROFILE"
+
+{{- if eq .chezmoi.os "darwin" }}
+# darwin-rebuild looks up darwinConfigurations.<hostname> in the flake.
+# The flake ships two entries — joes-macbook and agent-mac — so the hostname
+# must match one of those keys exactly. Set the hostname before running chezmoi
+# if it does not already match (System Preferences → Sharing → Computer Name).
+HOSTNAME="{{ .chezmoi.hostname }}"
+if command -v darwin-rebuild &>/dev/null; then
+  darwin-rebuild switch --flake "$FLAKE#$HOSTNAME"
+else
+  # First activation: bootstrap nix-darwin through the flake.
+  nix run nix-darwin -- switch --flake "$FLAKE#$HOSTNAME"
+fi
+{{- else }}
+# Linux: standalone home-manager keyed on <profile>-linux.
+# Known flake entries: agent-linux (home.username = "agent", /home/agent).
+# NOTE: agent-linux requires running as user "agent". When provisioned via
+# provision-lxd.sh --nix-profile agent the container creates user "jth",
+# causing a home-manager username mismatch error. Track as HOL-510.
+if command -v home-manager &>/dev/null; then
+  home-manager switch --flake "$FLAKE#${PROFILE}-linux"
+else
+  # First activation: bootstrap home-manager through the flake.
+  nix run home-manager -- switch --flake "$FLAKE#${PROFILE}-linux"
+fi
+{{- end }}
+
+echo "  ✓ Nix profile '$PROFILE' activated"

--- a/run_once_after_nix-profile.sh.tmpl
+++ b/run_once_after_nix-profile.sh.tmpl
@@ -55,9 +55,7 @@ fi
 {{- else }}
 # Linux: standalone home-manager keyed on <profile>-linux.
 # Known flake entries: agent-linux (home.username = "agent", /home/agent).
-# NOTE: agent-linux requires running as user "agent". When provisioned via
-# provision-lxd.sh --nix-profile agent the container creates user "jth",
-# causing a home-manager username mismatch error. Track as HOL-510.
+# provision-lxd.sh --nix-profile agent creates user "agent" to match the flake.
 if command -v home-manager &>/dev/null; then
   home-manager switch --flake "$FLAKE#${PROFILE}-linux"
 else

--- a/run_once_before_install-nix.sh.tmpl
+++ b/run_once_before_install-nix.sh.tmpl
@@ -3,6 +3,10 @@
 # Docs: https://install.determinate.systems
 set -e
 
+{{- if not (index . "nix_profile") }}
+exit 0
+{{- end }}
+
 if command -v nix &>/dev/null; then
   echo "  ✓ nix already installed ($(nix --version))"
   exit 0

--- a/scripts/provision-lxd.sh
+++ b/scripts/provision-lxd.sh
@@ -10,6 +10,7 @@
 # Usage:
 #   scripts/provision-lxd.sh --project <key> --name <container-name> [--dry-run]
 #                            [--host <ssh-target>] [--image <image>]
+#                            [--nix-profile <profile>]
 #
 # Constraints (see THE-68):
 #   - No long-lived secrets in user-data; only the single-use Tailscale auth key.
@@ -41,28 +42,36 @@ usage() {
   cat >&2 <<EOF
 Usage: $PROG --project <key> --name <container-name> [--dry-run]
                               [--host <ssh-target>] [--image <image>]
+                              [--nix-profile <profile>]
 
 Required:
-  --project <key>   chezmoi profile key (must match dot_Brewfile.<key> in repo)
-  --name <name>     LXD container name (e.g. the-legal-01)
+  --project <key>       chezmoi profile key (must match dot_Brewfile.<key> in repo)
+  --name <name>         LXD container name (e.g. the-legal-01)
 
 Optional:
-  --dry-run         print rendered cloud-init + proposed remote command; do
-                    NOT call doppler, do NOT contact the Proxmox host
-  --host <target>   SSH target for the Proxmox host
-                    (default: $DEFAULT_HOST; env: LXD_PROXMOX_HOST)
-  --image <image>   LXD image alias (default: $DEFAULT_IMAGE; env: LXD_IMAGE)
-  -h, --help        show this help and exit
+  --nix-profile <p>     Nix workspace profile to activate [joe|agent] (blank = no Nix).
+                        Seeds nix_profile in the pre-seeded chezmoi.toml so
+                        run_once_after_nix-profile.sh.tmpl activates the right flake output.
+                        NOTE: 'agent' requires user 'agent' in the flake (see agent-linux);
+                        the container user is 'jth' — activation will fail until HOL-510.
+  --dry-run             print rendered cloud-init + proposed remote command; do
+                        NOT call doppler, do NOT contact the Proxmox host
+  --host <target>       SSH target for the Proxmox host
+                        (default: $DEFAULT_HOST; env: LXD_PROXMOX_HOST)
+  --image <image>       LXD image alias (default: $DEFAULT_IMAGE; env: LXD_IMAGE)
+  -h, --help            show this help and exit
 
 Examples:
   $PROG --project legal --name the-legal-01 --dry-run
   $PROG --project legal --name the-legal-01
+  $PROG --project legal --name the-legal-01 --nix-profile agent --dry-run
 EOF
 }
 
 # ── parse args ──────────────────────────────────────────────────────────────
 project=""
 name=""
+nix_profile=""
 dry_run=0
 host="$DEFAULT_HOST"
 image="$DEFAULT_IMAGE"
@@ -79,6 +88,11 @@ while [[ $# -gt 0 ]]; do
       name="$2"; shift 2 ;;
     --name=*)
       name="${1#--name=}"; shift ;;
+    --nix-profile)
+      [[ $# -ge 2 ]] || die "--nix-profile requires a value"
+      nix_profile="$2"; shift 2 ;;
+    --nix-profile=*)
+      nix_profile="${1#--nix-profile=}"; shift ;;
     --host)
       [[ $# -ge 2 ]] || die "--host requires a value"
       host="$2"; shift 2 ;;
@@ -116,6 +130,11 @@ fi
 # Container name: LXD requires DNS-label-ish names.
 if ! [[ "$name" =~ ^[a-z0-9][a-z0-9-]{0,62}$ ]]; then
   die "invalid --name '$name': lowercase alphanumeric + hyphens, ≤63 chars, first char alphanumeric"
+fi
+
+# Nix profile: optional; when set must be a known flake key (joe or agent).
+if [[ -n "$nix_profile" ]] && ! [[ "$nix_profile" =~ ^(joe|agent)$ ]]; then
+  die "invalid --nix-profile '$nix_profile': must be 'joe' or 'agent' (or omit for no Nix)"
 fi
 
 # Resolve repo root from this script's directory.
@@ -165,7 +184,7 @@ fi
 # .chezmoi.toml.tmpl does NOT overwrite our values: chezmoi only renders the
 # config template when the destination is absent.
 render_cloud_init() {
-  local _project="$1" _name="$2" _authkey="$3"
+  local _project="$1" _name="$2" _authkey="$3" _nix_profile="$4"
   cat <<CLOUDINIT
 #cloud-config
 # Rendered by $PROG for project=$_project name=$_name
@@ -205,7 +224,7 @@ write_files:
       $_authkey
 
   # Pre-seed chezmoi config so the non-interactive .chezmoi.toml.tmpl branch
-  # does not clobber projects/lxd_profile with their empty defaults.
+  # does not clobber projects/lxd_profile/nix_profile with their empty defaults.
   - path: /home/jth/.config/chezmoi/chezmoi.toml
     permissions: '0600'
     owner: jth:jth
@@ -217,6 +236,7 @@ write_files:
           github_user = "Jobikinobi"
           projects = ["$_project"]
           lxd_profile = "$_project"
+          nix_profile = "$_nix_profile"
 
   # Bootstrap script run as jth: install chezmoi, init+apply from GitHub.
   # The age decryption key (~/.config/chezmoi/key.txt) is NOT provisioned here
@@ -251,12 +271,12 @@ final_message: |
 CLOUDINIT
 }
 
-cloud_init="$(render_cloud_init "$project" "$name" "$ts_authkey")"
+cloud_init="$(render_cloud_init "$project" "$name" "$ts_authkey" "$nix_profile")"
 
 # ── dry-run: print and exit ────────────────────────────────────────────────
 if (( dry_run )); then
   cat <<EOF
-# ── rendered cloud-init ── (project=$project name=$name; auth key REDACTED)
+# ── rendered cloud-init ── (project=$project name=$name nix_profile=${nix_profile:-<none>}; auth key REDACTED)
 $cloud_init
 
 # ── proposed remote invocation ──
@@ -311,5 +331,5 @@ if ! printf '%s' "$cloud_init" | ssh -T "$host" "$remote_cmd"; then
   die "remote lxc launch failed on $host (image=$image name=$name); cloud-init was not applied."
 fi
 
-printf '%s: launched %s on %s (image=%s, project=%s)\n' \
-  "$PROG" "$name" "$host" "$image" "$project"
+printf '%s: launched %s on %s (image=%s, project=%s, nix_profile=%s)\n' \
+  "$PROG" "$name" "$host" "$image" "$project" "${nix_profile:-<none>}"

--- a/scripts/provision-lxd.sh
+++ b/scripts/provision-lxd.sh
@@ -52,8 +52,8 @@ Optional:
   --nix-profile <p>     Nix workspace profile to activate [joe|agent] (blank = no Nix).
                         Seeds nix_profile in the pre-seeded chezmoi.toml so
                         run_once_after_nix-profile.sh.tmpl activates the right flake output.
-                        NOTE: 'agent' requires user 'agent' in the flake (see agent-linux);
-                        the container user is 'jth' — activation will fail until HOL-510.
+                        'agent' containers run as user 'agent' to match the flake's
+                        homeConfigurations."agent-linux" (home.username = "agent").
   --dry-run             print rendered cloud-init + proposed remote command; do
                         NOT call doppler, do NOT contact the Proxmox host
   --host <target>       SSH target for the Proxmox host
@@ -185,6 +185,21 @@ fi
 # config template when the destination is absent.
 render_cloud_init() {
   local _project="$1" _name="$2" _authkey="$3" _nix_profile="$4"
+
+  # agent-profile containers run as "agent" to match the flake's
+  # homeConfigurations."agent-linux" (home.username = "agent", /home/agent).
+  # All other profiles (including no Nix) use "jth".
+  local _user _home_dir _gecos
+  if [[ "$_nix_profile" == "agent" ]]; then
+    _user="agent"
+    _home_dir="/home/agent"
+    _gecos="HOLE Foundation Agent"
+  else
+    _user="jth"
+    _home_dir="/home/jth"
+    _gecos="Joseph T. Herrmann, M.D."
+  fi
+
   cat <<CLOUDINIT
 #cloud-config
 # Rendered by $PROG for project=$_project name=$_name
@@ -192,8 +207,8 @@ hostname: $_name
 manage_etc_hosts: localhost
 
 users:
-  - name: jth
-    gecos: Joseph T. Herrmann, M.D.
+  - name: $_user
+    gecos: $_gecos
     shell: /bin/bash
     sudo: ALL=(ALL) NOPASSWD:ALL
     groups: [sudo, adm]
@@ -225,9 +240,9 @@ write_files:
 
   # Pre-seed chezmoi config so the non-interactive .chezmoi.toml.tmpl branch
   # does not clobber projects/lxd_profile/nix_profile with their empty defaults.
-  - path: /home/jth/.config/chezmoi/chezmoi.toml
+  - path: $_home_dir/.config/chezmoi/chezmoi.toml
     permissions: '0600'
-    owner: jth:jth
+    owner: $_user:$_user
     defer: true
     content: |
       [data]
@@ -250,7 +265,7 @@ write_files:
     content: |
       #!/usr/bin/env bash
       set -euo pipefail
-      sudo -u jth -H bash -lc '
+      sudo -u $_user -H bash -lc '
         mkdir -p "\$HOME/.local/bin"
         if ! command -v chezmoi >/dev/null 2>&1 && [ ! -x "\$HOME/.local/bin/chezmoi" ]; then
           sh -c "\$(curl -fsLS https://get.chezmoi.io)" -- -b "\$HOME/.local/bin"
@@ -267,7 +282,7 @@ runcmd:
 
 final_message: |
   cloud-init complete for $_name (project=$_project). Uptime: \$UPTIME s.
-  Login: ssh jth@$_name   (over tailnet, MagicDNS)
+  Login: ssh $_user@$_name   (over tailnet, MagicDNS)
 CLOUDINIT
 }
 


### PR DESCRIPTION
## Summary

- Adds `nix_profile` prompt to `.chezmoi.toml.tmpl` — interactive branch prompts `[joe/agent] (blank for no Nix)`, headless branch defaults to `""`.
- Gates `run_once_before_install-nix.sh.tmpl` on `nix_profile` being set — Nix is not installed when the prompt is left blank.
- Creates `run_once_after_nix-profile.sh.tmpl` — activates the correct flake output after apply; uses `nix run nix-darwin` / `nix run home-manager` on first activation (no bare binary assumed), falls back to installed binary on subsequent runs.
- Adds `--nix-profile <profile>` to `scripts/provision-lxd.sh` — validates against known flake keys (`joe`, `agent`), pre-seeds `nix_profile` in the cloud-init chezmoi.toml, documented in `--help`.
- Updates `docs/profiles/README.md` — `nix_profile` added to Data variables section; LXD provisioning examples include `--nix-profile` flag.

## Known limitation

`--nix-profile agent` on an LXD container hits a username mismatch: `homeConfigurations."agent-linux"` in the flake pins `home.username = "agent"` but the container creates user `jth`. home-manager standalone will refuse activation. Tracked as HOL-510.

## Verification

- `chezmoi execute-template --stdinisatty=false < .chezmoi.toml.tmpl` → headless branch includes `nix_profile = ""`
- `shellcheck scripts/provision-lxd.sh` → clean
- `scripts/provision-lxd.sh --project legal --name x --nix-profile agent --dry-run` → cloud-init renders `nix_profile = "agent"`
- `scripts/provision-lxd.sh --project legal --name x --nix-profile bogus --dry-run` → exits 1 with clear error
- `scripts/provision-lxd.sh --project legal --name x --dry-run` → cloud-init renders `nix_profile = ""`

End-to-end container activation (Doppler + Proxmox + LXD) is deferred to HOL-510 (username reconciliation is a prerequisite for a clean `--nix-profile agent` run).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)