### PR TITLE
ci(nix): Linux build job, eval caching, local smoke-test (HOL-510)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,18 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@v14
 
+      # Cache the Nix evaluation store (~/.cache/nix). This is safe to restore
+      # after nix-installer-action because it only contains evaluation results
+      # (attribute sets, derivation hashes), not the package store itself.
+      # Binary packages are fetched from cache.nixos.org (the default substituter).
+      - name: Cache Nix evaluation cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/nix
+          key: nix-eval-${{ runner.os }}-${{ hashFiles('nix/flake.lock') }}
+          restore-keys: |
+            nix-eval-${{ runner.os }}-
+
       - name: Lock flake inputs
         run: nix flake lock ./nix
 
@@ -174,5 +186,44 @@ jobs:
 
       - name: Check flake
         # --no-build: evaluate all outputs without building derivations.
-        # Appropriate for P2 stubs; remove in P3/P4 once outputs produce packages.
+        # darwin-rebuild switch is not run in CI (cost/benefit: macOS runners are
+        # expensive and darwin builds take 30+ min). The darwin configs are
+        # validated by evaluation only; see docs/conventions/nix-ci.md.
         run: nix flake check --no-build ./nix
+
+  # ── Nix: build Linux home-manager activation packages ─────────────────────
+  # Builds homeConfigurations.<profile>.activationPackage on a native
+  # x86_64-linux runner. This proves the packages download and assemble
+  # correctly on Linux — nix flake check --no-build only evaluates expressions.
+  #
+  # Matrix: currently only agent-linux (the profile merged to main).
+  # Add joe-linux here when homeConfigurations."joe-linux" lands on main.
+  # darwin-joe (darwinConfigurations."joes-macbook") is validated by the
+  # macOS --no-build eval above; full darwin-rebuild is out of CI scope.
+  # See docs/conventions/nix-ci.md for the rationale.
+  nix-agent-linux-build:
+    name: nix build ${{ matrix.profile }}
+    runs-on: ubuntu-latest
+    needs: nix-flake-check
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [agent-linux]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: DeterminateSystems/nix-installer-action@v14
+
+      - name: Cache Nix evaluation cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/nix
+          key: nix-eval-${{ runner.os }}-${{ hashFiles('nix/flake.lock') }}
+          restore-keys: |
+            nix-eval-${{ runner.os }}-
+
+      - name: Build ${{ matrix.profile }} activation package
+        run: nix build ./nix#homeConfigurations.${{ matrix.profile }}.activationPackage --no-link --print-out-paths

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -9,6 +9,7 @@ Policy docs that govern how this repo is used day-to-day.
 | File | One-line rule |
 |---|---|
 | [`conventions/workspace-directory-layout.md`](conventions/workspace-directory-layout.md) | Canonical `~/` tree — `projects/`, `docs/`, `bin/`, `scratch/`, etc. |
+| [`conventions/nix-ci.md`](conventions/nix-ci.md) | What Nix checks run in CI, what doesn't (darwin cost), and local smoke-test path. |
 
 ## Standards (imported — Legal-Assistant-v3)
 

--- a/docs/conventions/nix-ci.md
+++ b/docs/conventions/nix-ci.md
@@ -1,0 +1,48 @@
+# Nix CI contract
+
+How the Nix layer is validated in CI and locally.
+
+## CI jobs (`.github/workflows/ci.yml`)
+
+| Job | Runner | What it checks |
+|---|---|---|
+| `nix-flake-check` | `macos-latest` | Evaluates all flake outputs (`--no-build`). Catches syntax errors, missing attrs, eval errors. Validates both `darwinConfigurations` and `homeConfigurations`. |
+| `nix-agent-linux-build` | `ubuntu-latest` | Builds `homeConfigurations.agent-linux.activationPackage` on a native x86_64-linux runner. Proves packages download and assemble correctly on Linux. |
+
+### What is NOT run in CI
+
+- **`darwin-rebuild switch`** — building the full `darwinConfigurations."joes-macbook"` derivation in CI is not done. macOS GitHub Actions runners are expensive (~10× Linux cost) and a full nix-darwin build takes 30+ minutes. The `--no-build` eval on macOS is sufficient to catch nix expression errors. Physical mac applies are the acceptance gate for darwin configs.
+
+- **`joe-linux` build** — `homeConfigurations."joe-linux"` is added to the matrix when that configuration lands on `main`. It is currently defined on a feature branch.
+
+### Caching strategy
+
+Both nix jobs cache `~/.cache/nix` (the Nix evaluation cache) keyed on `nix/flake.lock`. This avoids re-evaluating the full nixpkgs attribute tree on every run. Binary packages are fetched from `cache.nixos.org` (the default Nix substituter) — no additional binary cache is configured.
+
+To add a binary cache (e.g. Cachix), set `extra-substituters` in `nix/nix.conf` and add the public key to `extra-trusted-public-keys`. This requires no secrets if the cache is public.
+
+## Local smoke tests (`scripts/test-profile.sh --nix-profile`)
+
+Run the Linux activation build locally:
+
+```bash
+# Requires nix on PATH
+scripts/test-profile.sh --nix-profile agent-linux
+```
+
+This is the local equivalent of the `nix-agent-linux-build` CI job. It builds `homeConfigurations.agent-linux.activationPackage` from `nix/flake.nix` without activating.
+
+For verbose build output on failure:
+
+```bash
+nix build ./nix#homeConfigurations.agent-linux.activationPackage -L
+```
+
+## Adding a new Nix profile to CI
+
+1. Add the `homeConfigurations."<key>"` output to `nix/flake.nix`.
+2. Add `<key>` to the `matrix.profile` list in the `nix-agent-linux-build` job in `.github/workflows/ci.yml`.
+3. Verify locally: `scripts/test-profile.sh --nix-profile <key>`.
+4. Open a PR — both `nix-flake-check` and `nix-agent-linux-build` must pass.
+
+For `darwinConfigurations`, the `nix-flake-check` job validates them automatically. No separate CI step is added unless full build validation is later deemed necessary.

--- a/scripts/test-profile.sh
+++ b/scripts/test-profile.sh
@@ -1,20 +1,31 @@
 #!/usr/bin/env bash
-# test-profile.sh — Docker-backed verification gate for chezmoi profiles.
+# test-profile.sh — Docker-backed verification gate for chezmoi profiles,
+# with an optional Nix smoke-test path (--nix-profile).
 #
-# Given a profile key (legal, godocs, oversight, core), builds the existing
-# Dockerfile.test with CHEZMOI_PROJECT=<key> baked in, applies chezmoi inside
-# the container, then asserts the binaries declared in docs/profiles/<key>.md
-# are actually on PATH inside the resulting image.
+# CHEZMOI MODE (default):
+#   Given a profile key (legal, godocs, oversight, core), builds the existing
+#   Dockerfile.test with CHEZMOI_PROJECT=<key> baked in, applies chezmoi inside
+#   the container, then asserts the binaries declared in docs/profiles/<key>.md
+#   are actually on PATH inside the resulting image.
+#
+# NIX MODE (--nix-profile):
+#   Given a Nix profile key (agent-linux, joe-linux), evaluates and builds
+#   the corresponding homeConfigurations.<key>.activationPackage from nix/flake.nix.
+#   Requires `nix` on PATH. This is the local equivalent of the CI
+#   `nix-agent-linux-build` job. Does NOT require Docker.
 #
 # Usage:
 #   scripts/test-profile.sh --project <key> [--branch <branch>] [--no-cache]
 #                                            [--keep-images]
+#   scripts/test-profile.sh --nix-profile <key>
 #
 # Exit codes:
 #   0   success — image built and every declared binary is on PATH (or, for
-#       a docs-only profile, the brew-list diff against core is empty).
+#       a docs-only profile, the brew-list diff against core is empty). In nix
+#       mode: activationPackage built successfully.
 #   1   verification failure — at least one declared binary is missing, OR a
-#       docs-only profile installed extras beyond the core baseline.
+#       docs-only profile installed extras beyond the core baseline. In nix
+#       mode: build failed.
 #   2   usage / argument error.
 #
 # Conventions parsed:
@@ -24,6 +35,7 @@
 #   marks a "docs-only" profile and triggers the brew-list diff path.
 #
 # See docs/profiles/README.md#verification for the full convention.
+# See docs/conventions/nix-ci.md for the Nix CI contract.
 #
 # Constraints:
 #   - ShellCheck clean.
@@ -43,21 +55,25 @@ die() { err "$*"; exit 2; }
 usage() {
   cat >&2 <<EOF
 Usage: $PROG --project <key> [--branch <branch>] [--no-cache] [--keep-images]
+       $PROG --nix-profile <key>
 
-Required:
+Chezmoi mode (Docker-backed):
   --project <key>   Profile key to validate. Must be one of:
                       - "core" (baseline build only)
                       - or a populated profile (\$repo_root/dot_Brewfile.<key>
                         + docs/profiles/<key>.md must both exist)
 
-Optional:
   --branch <ref>    Chezmoi branch to clone inside the image (default: main).
                     Pushed to Docker as --build-arg CHEZMOI_BRANCH=<ref>.
-                    Useful for iterating on a feature branch before merge.
-  --no-cache        Pass --no-cache to docker build. By default the build
-                    cache is reused so reruns across profiles are fast.
-  --keep-images     Skip the rmi of intermediate images at the end. Handy
-                    for poking around with \`docker run -it\`.
+  --no-cache        Pass --no-cache to docker build.
+  --keep-images     Skip the rmi of intermediate images at the end.
+
+Nix mode (requires \`nix\` on PATH):
+  --nix-profile <key>   Nix profile to smoke-test. Known values: agent-linux.
+                        Builds homeConfigurations.<key>.activationPackage from
+                        nix/flake.nix. No Docker required.
+                        Local equivalent of the CI nix-agent-linux-build job.
+
   -h, --help        Show this help and exit.
 
 Examples:
@@ -65,17 +81,24 @@ Examples:
   $PROG --project godocs --branch feat/godocs-cleanup
   $PROG --project oversight       # asserts docs-only invariant
   $PROG --project core            # baseline build, no per-profile asserts
+  $PROG --nix-profile agent-linux # build Nix activation package locally
 EOF
 }
 
 # ── argument parsing ────────────────────────────────────────────────────────
 project=""
+nix_profile=""
 branch="main"
 no_cache=0
 keep_images=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --nix-profile)
+      [[ $# -ge 2 ]] || die "--nix-profile requires a value"
+      nix_profile="$2"; shift 2 ;;
+    --nix-profile=*)
+      nix_profile="${1#--nix-profile=}"; shift ;;
     --project)
       [[ $# -ge 2 ]] || die "--project requires a value"
       project="$2"; shift 2 ;;
@@ -102,7 +125,39 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -n "$project" ]] || { err "--project is required"; usage; exit 2; }
+# Exactly one of --project or --nix-profile must be supplied.
+if [[ -n "$nix_profile" && -n "$project" ]]; then
+  die "--project and --nix-profile are mutually exclusive"
+fi
+
+# ── Nix smoke-test mode ──────────────────────────────────────────────────────
+if [[ -n "$nix_profile" ]]; then
+  # Validate key shape (same convention as --project).
+  if ! [[ "$nix_profile" =~ ^[a-z][a-z0-9-]{0,19}$ ]]; then
+    die "invalid --nix-profile '$nix_profile': must be lowercase kebab-case, ≤20 chars, start with a letter"
+  fi
+
+  command -v nix >/dev/null 2>&1 || die "nix is not on PATH — install Nix first (see https://nixos.org/download)"
+
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
+  repo_root="$(cd "$script_dir/.." && pwd)"
+
+  flake="$repo_root/nix"
+  [[ -f "$flake/flake.nix" ]] || die "missing $flake/flake.nix (is this the dotfiles repo root?)"
+
+  attr="homeConfigurations.$nix_profile.activationPackage"
+  printf '%s: building %s from %s#%s\n' "$PROG" "$nix_profile" "$flake" "$attr" >&2
+  if nix build "$flake#$attr" --no-link --print-out-paths; then
+    printf '%s: ✓ nix profile %s built successfully.\n' "$PROG" "$nix_profile"
+    exit 0
+  else
+    err "✗ nix build failed for profile '$nix_profile' (attr: $attr)"
+    err "Run: nix build $flake#$attr -L  for verbose build logs."
+    exit 1
+  fi
+fi
+
+[[ -n "$project" ]] || { err "--project or --nix-profile is required"; usage; exit 2; }
 
 # Profile key shape: lowercase, kebab-case, ≤12 chars, starts with a letter.
 # Matches the convention used in docs/profiles/README.md and provision-lxd.sh.


### PR DESCRIPTION
## Summary

- **Already done (HOL-506/507/508/509):** `nix flake check --no-build` runs on every PR via the `nix-flake-check` macOS job. Done-criterion #1 was satisfied before this PR.
- **This PR adds:** Linux build job, nix evaluation caching, `--nix-profile` local smoke test, and the CI contract doc.

### Changes

- `.github/workflows/ci.yml` — add `~/.cache/nix` eval caching to `nix-flake-check`; add new `nix-agent-linux-build` job (ubuntu-latest, matrix: `[agent-linux]`) that builds `homeConfigurations.agent-linux.activationPackage`
- `scripts/test-profile.sh` — add `--nix-profile <key>` flag (local equivalent of CI build, requires `nix`, no Docker)
- `docs/conventions/nix-ci.md` — new: CI job table, caching strategy, why darwin-rebuild is not in CI (macOS runner cost), how to add a new profile
- `docs/INDEX.md` — link `nix-ci.md` from Conventions table

### Darwin-joe rationale (documented in nix-ci.md)

`darwin-rebuild switch` for `darwinConfigurations."joes-macbook"` is not run in CI. macOS GHA runners cost ~10× Linux and a full nix-darwin build takes 30+ minutes. The `--no-build` eval on the macOS `nix-flake-check` job is sufficient to catch nix expression errors. Physical mac applies are the acceptance gate.

### Note on `joe-linux`

`homeConfigurations."joe-linux"` is stranded on an unmerged branch (commit `08d5ffa`). It is NOT added to the matrix here (building a config not on main would fail). Tracked separately.

## Test plan

- [ ] `nix-flake-check` job passes on macOS (eval + lock commit)
- [ ] `nix-agent-linux-build` job passes on ubuntu-latest (builds activation package)
- [ ] ShellCheck passes on `scripts/test-profile.sh` (clean pre-commit)
- [ ] `scripts/test-profile.sh --nix-profile agent-linux` runs successfully locally when `nix` is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)