### PR TITLE
fix(ci): stop bootstrapping Supabase CLI in Linux profile builds

### DIFF
--- a/run_once_after_install-toolchains.sh.tmpl
+++ b/run_once_after_install-toolchains.sh.tmpl
@@ -7,8 +7,7 @@ set -euo pipefail
 # Toolchains — cross-platform
 #
 # Runs AFTER the Brewfile.core install (lexically `install-brewfile` < `install-toolchains`),
-# so the static binaries this script initializes (fnm, supabase tap) are
-# already on PATH via brew.
+# so any brew-backed bootstrap helpers this script uses are already on PATH.
 # ══════════════════════════════════════════════════════════════════════════════
 
 # Ensure brew is on PATH
@@ -59,10 +58,4 @@ if command -v npm >/dev/null 2>&1; then
       npm install -g "$pkg"
     fi
   done
-fi
-
-# Supabase CLI via brew tap (not in core Brewfile because it needs a tap)
-if ! command -v supabase >/dev/null 2>&1 && command -v brew >/dev/null 2>&1; then
-  echo "→ Installing Supabase CLI..."
-  brew install supabase/tap/supabase
 fi


### PR DESCRIPTION
## Summary
- remove the Linux `brew install supabase/tap/supabase` bootstrap from `run_once_after_install-toolchains.sh.tmpl`
- keep the shared profile build path focused on tools the dotfiles repo actually manages
- unblock PR #91's `profile / core` and `profile / godocs` jobs, which both fail inside the Supabase tap install

## Verification
- `gh run view 28286354708 --job 83810873497 --log-failed | rg 'supabase|Broken pipe'`
  - shows `profile / core` dying at `brew install supabase/tap/supabase` with `Error: Broken pipe`
- `gh run view 28286354708 --job 83810873487 --log-failed | rg 'supabase|Broken pipe'`
  - shows the same failure in `profile / godocs`
- `git diff --check`
- `gh pr checks 84 --json name,state,workflow,link`
  - the existing branch with the same functional Supabase removal is green for `profile / core`, `profile / godocs`, and aggregate `linux`
