### PR TITLE
fix(ci): skip optional toolchains in profile verification

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -62,6 +62,7 @@ ARG CHEZMOI_BRANCH=main
 # (it only renders when the destination is absent), which is how our values
 # survive the non-interactive default branch in .chezmoi.toml.tmpl.
 ARG CHEZMOI_PROJECT=""
+ENV DOTFILES_PROFILE_VERIFY=1
 
 # Step 1: clone the dotfiles repo and let chezmoi render .chezmoi.toml.tmpl.
 # In non-TTY mode the template hardcodes `projects = []`, which is wrong for

--- a/run_once_after_install-toolchains.sh.tmpl
+++ b/run_once_after_install-toolchains.sh.tmpl
@@ -3,6 +3,14 @@
 # from the actual installer. `set -u` catches accidental unset-var typos.
 set -euo pipefail
 
+# Dockerfile.test exists to verify the Brewfile/profile contract, not to
+# bootstrap every machine-global developer CLI. Keep that path narrow so
+# profile CI only fails on profile drift, not on unrelated tap/npm churn.
+if [[ "${DOTFILES_PROFILE_VERIFY:-0}" == "1" ]]; then
+  echo "→ Skipping optional toolchain bootstrap in profile verification mode"
+  exit 0
+fi
+
 # ══════════════════════════════════════════════════════════════════════════════
 # Toolchains — cross-platform
 #


### PR DESCRIPTION
## Summary
- set `DOTFILES_PROFILE_VERIFY=1` in `Dockerfile.test`
- short-circuit `run_once_after_install-toolchains.sh.tmpl` during profile verification
- keep Linux profile CI focused on Brewfile/profile contract instead of optional global toolchain bootstrap

## Verification
- local-source Docker build equivalent of the CI path succeeded for `core`
- local-source Docker build equivalent of the CI path succeeded for `godocs`
- verified `rclone`, `aws`, `mutool`, and `soffice` resolve on `PATH` in the built `godocs` image