### PR TITLE
feat(bootstrap): sudo-less agent-space deploy (#99)

### DIFF
--- a/run_once_after_install-brewfile.sh.tmpl
+++ b/run_once_after_install-brewfile.sh.tmpl
@@ -62,9 +62,24 @@ if ! command -v brew >/dev/null 2>&1; then
       ripgrep        # grep replacement
       zsh            # login shell
     )
-    sudo apk add --no-cache "${APK_CORE_PACKAGES[@]}" || {
-      echo "  ⚠ Some apk packages may not be available in this Alpine version — continuing"
-    }
+    # Privilege-aware (#99): root runs apk directly; a self-deploy uses
+    # passwordless sudo; an unprivileged agent-space can't apk and relies on the
+    # provisioning phase having installed these already.
+    if [[ "$(id -u)" -eq 0 ]]; then
+      APK_SUDO=""
+    elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+      APK_SUDO="sudo"
+    else
+      APK_SUDO="none"
+    fi
+    if [[ "$APK_SUDO" == "none" ]]; then
+      echo "  ⚠ Unprivileged agent-space on Alpine — cannot apk add core tools."
+      echo "    Provisioning phase should install: ${APK_CORE_PACKAGES[*]}"
+    else
+      $APK_SUDO apk add --no-cache "${APK_CORE_PACKAGES[@]}" || {
+        echo "  ⚠ Some apk packages may not be available in this Alpine version — continuing"
+      }
+    fi
     # Tools not available in apk (doppler, fnm, gh, lazygit, lazyssh, uv,
     # git-filter-repo, pyenv, powerlevel10k) are left for manual install.
     echo "  ℹ doppler, fnm, gh, lazygit, uv, and pyenv are not in apk."

--- a/run_once_before_00-linux-bootstrap.sh.tmpl
+++ b/run_once_before_00-linux-bootstrap.sh.tmpl
@@ -19,14 +19,26 @@
 
 set -e
 
-# ── Privilege escalation ─────────────────────────────────────────────────────
-# If running as root (Docker RUN, or `sudo chezmoi apply`), no sudo needed.
-# Otherwise, expect sudo to be available or install it first where possible.
+# ── Privilege capability detection (#99) ──────────────────────────────────────
+# Three deployment modes, not two:
+#   root → run privileged ops directly (Docker RUN, `sudo chezmoi apply`)
+#   sudo → passwordless sudo available (self-deploy on a machine you own)
+#   none → unprivileged agent-space: a separate root/provisioning phase already
+#          installed system prerequisites and set the login shell. We SKIP
+#          privileged steps rather than fail, because laying down dotfiles needs
+#          no privilege. This is the "deploy from root into an agent space"
+#          model rather than self-deploy-only.
 if [ "$(id -u)" -eq 0 ]; then
+  PRIV=root
   SUDO=""
-else
+elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+  PRIV=sudo
   SUDO="sudo"
+else
+  PRIV=none
+  SUDO=""
 fi
+echo "→ Privilege mode: ${PRIV}"
 
 # ── Distro detection ─────────────────────────────────────────────────────────
 # Source /etc/os-release (POSIX-safe: . rather than source)
@@ -55,6 +67,23 @@ fi
 echo "→ Detected OS family: ${OS_FAMILY} (ID=${ID:-unknown})"
 
 # ── Installation dispatch ────────────────────────────────────────────────────
+# Unprivileged agent-space: we cannot install system packages. Assume the
+# provisioning (root) phase already did, verify the essentials, and warn if any
+# are missing — but never fail, since dotfile deployment itself needs no root.
+if [ "$PRIV" = "none" ]; then
+  MISSING=""
+  for bin in git curl zsh; do
+    command -v "$bin" >/dev/null 2>&1 || MISSING="$MISSING $bin"
+  done
+  if [ -n "$MISSING" ]; then
+    echo "⚠ Unprivileged deploy and missing prerequisites:$MISSING"
+    echo "  The root/provisioning phase must install these before deploying"
+    echo "  dotfiles into this agent space (see scripts/agent-provision.sh)."
+    echo "  Continuing — dotfiles will still be laid down."
+  else
+    echo "→ Unprivileged agent-space: prerequisites already present, skipping system install"
+  fi
+else
 case "$OS_FAMILY" in
 
   # ── Debian / Ubuntu ──────────────────────────────────────────────────────
@@ -152,12 +181,17 @@ case "$OS_FAMILY" in
     echo "  Manually install: bash build-tools curl file git gnupg procps zsh"
     ;;
 esac
+fi
 
-# ── Set zsh as the login shell ───────────────────────────────────────────────
+# ── Set zsh as the login shell (privileged only) ─────────────────────────────
+# In agent-space (unprivileged) mode the provisioning phase owns the login
+# shell; changing it here would need root we don't have.
 TARGET_USER="$(id -un 2>/dev/null || whoami 2>/dev/null || true)"
 ZSH_PATH="$(command -v zsh 2>/dev/null || true)"
 
-if [ -n "$ZSH_PATH" ] && [ -n "$TARGET_USER" ]; then
+if [ "$PRIV" = "none" ]; then
+  echo "→ Unprivileged: leaving login-shell setup to the provisioning phase"
+elif [ -n "$ZSH_PATH" ] && [ -n "$TARGET_USER" ]; then
   if ! grep -qxF "$ZSH_PATH" /etc/shells 2>/dev/null; then
     echo "$ZSH_PATH" | $SUDO tee -a /etc/shells > /dev/null
   fi

--- a/scripts/agent-provision.sh
+++ b/scripts/agent-provision.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# agent-provision.sh — root/provisioning phase for the "deploy into an agent
+# space" model (#99).
+#
+# Run this as root (or via sudo) to prepare a machine/container so that an
+# UNPRIVILEGED agent user can then deploy dotfiles with `chezmoi apply` and
+# needs no sudo of its own. This is the counterpart to the sudo-less run_once
+# scripts: everything that requires privilege happens here, once, up front.
+#
+# What it does (all the privileged work):
+#   1. Installs system prerequisites via the distro's package manager
+#   2. Creates the agent user (if missing) with a zsh login shell
+#   3. Installs Homebrew into the shared /home/linuxbrew prefix (glibc only;
+#      skipped on Alpine/musl) and exposes it via /etc/profile.d
+#
+# What it deliberately does NOT do:
+#   - Grant the agent sudo. The whole point is a sudo-less agent space. Pass
+#     --with-sudo only if you explicitly want passwordless sudo for the agent.
+#
+# Usage:
+#   sudo scripts/agent-provision.sh <username> [--with-sudo]
+#
+# Afterwards, deploy as the agent (no root needed):
+#   su - <username> -c 'chezmoi init --apply Jobikinobi'
+
+set -euo pipefail
+
+AGENT_USER="${1:-agent}"
+WITH_SUDO=0
+for arg in "$@"; do
+  [ "$arg" = "--with-sudo" ] && WITH_SUDO=1
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "✗ Must run as root (or via sudo). Try: sudo $0 $AGENT_USER" >&2
+  exit 1
+fi
+
+# ── Distro detection (mirrors run_once_before_00-linux-bootstrap) ─────────────
+OS_FAMILY="unknown"
+if [ -f /etc/os-release ]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  case "${ID:-}" in
+    ubuntu|debian|linuxmint|pop|kali)                 OS_FAMILY="debian" ;;
+    alpine)                                           OS_FAMILY="alpine" ;;
+    rhel|centos|fedora|rocky|almalinux|ol|scientific) OS_FAMILY="rhel" ;;
+    arch|manjaro|endeavouros)                         OS_FAMILY="arch" ;;
+    *)
+      case "${ID_LIKE:-}" in
+        *debian*)                 OS_FAMILY="debian" ;;
+        *rhel*|*fedora*|*centos*) OS_FAMILY="rhel"   ;;
+        *arch*)                   OS_FAMILY="arch"   ;;
+      esac
+      ;;
+  esac
+fi
+echo "→ OS family: ${OS_FAMILY} (ID=${ID:-unknown}); agent user: ${AGENT_USER}"
+
+# ── 1. System prerequisites ───────────────────────────────────────────────────
+case "$OS_FAMILY" in
+  debian)
+    DEBIAN_FRONTEND=noninteractive apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+      build-essential ca-certificates curl file git gnupg procps sudo zsh
+    ;;
+  alpine)
+    if ! grep -qE '^[^#].*/community' /etc/apk/repositories 2>/dev/null; then
+      MAIN_REPO=$(grep -m1 'http' /etc/apk/repositories 2>/dev/null | sed 's|/main||')
+      [ -n "$MAIN_REPO" ] && echo "${MAIN_REPO}/community" >> /etc/apk/repositories
+    fi
+    apk update -q
+    apk add --no-cache bash build-base ca-certificates curl file git gnupg procps shadow sudo zsh
+    ;;
+  rhel)
+    PKG_MGR=$(command -v dnf || command -v yum)
+    [ -n "$PKG_MGR" ] || { echo "✗ no dnf/yum" >&2; exit 1; }
+    command -v dnf >/dev/null 2>&1 && ! rpm -q epel-release >/dev/null 2>&1 \
+      && dnf install -y epel-release 2>/dev/null || true
+    "$PKG_MGR" install -y \
+      ca-certificates file findutils gcc gcc-c++ git glibc-devel gnupg2 make procps-ng sudo zsh
+    ;;
+  arch)
+    pacman -Sy --noconfirm --needed \
+      base-devel ca-certificates curl file git gnupg procps-ng sudo zsh
+    ;;
+  *)
+    echo "⚠ Unrecognised distro — install manually: build-tools curl git gnupg zsh" ;;
+esac
+
+# ── 2. Create the agent user with a zsh login shell ───────────────────────────
+ZSH_PATH="$(command -v zsh || echo /bin/zsh)"
+if ! grep -qxF "$ZSH_PATH" /etc/shells 2>/dev/null; then
+  echo "$ZSH_PATH" >> /etc/shells
+fi
+if ! id "$AGENT_USER" >/dev/null 2>&1; then
+  echo "→ Creating user ${AGENT_USER}"
+  if [ "$OS_FAMILY" = "alpine" ]; then
+    adduser -D -s "$ZSH_PATH" "$AGENT_USER"
+  else
+    useradd -m -s "$ZSH_PATH" "$AGENT_USER"
+  fi
+else
+  # Ensure the shell is zsh even if the user pre-existed.
+  usermod -s "$ZSH_PATH" "$AGENT_USER" 2>/dev/null || true
+fi
+
+if [ "$WITH_SUDO" -eq 1 ]; then
+  echo "→ Granting passwordless sudo to ${AGENT_USER} (--with-sudo)"
+  printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$AGENT_USER" > "/etc/sudoers.d/90-agent-${AGENT_USER}"
+  chmod 0440 "/etc/sudoers.d/90-agent-${AGENT_USER}"
+else
+  echo "→ Leaving ${AGENT_USER} WITHOUT sudo (rootless agent space)"
+fi
+
+# ── 3. Shared Homebrew (glibc only; Alpine uses apk in the apply phase) ───────
+if [ "$OS_FAMILY" != "alpine" ]; then
+  if [ ! -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+    echo "→ Installing Homebrew (shared prefix) as ${AGENT_USER}"
+    su - "$AGENT_USER" -c 'NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+  fi
+  cat > /etc/profile.d/linuxbrew.sh <<'PROFILE'
+if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi
+PROFILE
+  chmod 0644 /etc/profile.d/linuxbrew.sh
+fi
+
+echo "✓ Agent space provisioned for ${AGENT_USER}."
+echo "  Deploy dotfiles (no root needed):"
+echo "    su - ${AGENT_USER} -c 'chezmoi init --apply Jobikinobi'"


### PR DESCRIPTION
Closes the core of #99 — the current bootstrap assumes self-deploy with sudo; this adds a **deploy-from-root-into-an-agent-space** model where the agent user has **no sudo**.

## What changed
The Linux bootstrap gains a **third privilege mode**:

| mode | when | behaviour |
|------|------|-----------|
| `root` | `id -u == 0` (Docker RUN, `sudo chezmoi apply`) | run privileged ops directly |
| `sudo` | passwordless sudo available (self-deploy) | escalate via sudo (unchanged) |
| `none` | unprivileged agent-space | **skip** privileged steps with a warning; lay down dotfiles anyway |

- `run_once_before_00-linux-bootstrap`: 3-way detection; when unprivileged, verify `git/curl/zsh` are present (warn if not), skip system package install + login-shell change.
- `run_once_after_install-brewfile`: the Alpine `apk` path is now privilege-aware.
- **`scripts/agent-provision.sh`** (new): the root-phase companion. Prepares an agent space — system deps + user + zsh shell + shared Homebrew — and deliberately does **not** grant the agent sudo (`--with-sudo` opt-in if you want it). Distro-aware including **Arch**.

## Two-phase model
```
# root / orchestrator, once per machine:
sudo scripts/agent-provision.sh agent
# then the agent, no root needed:
su - agent -c 'chezmoi init --apply Jobikinobi'
```

## Verification
Rendered the bootstrap and ran it as a non-root user with `sudo` forced to fail → detects `PRIV=none`, skips privileged steps, exits 0. Existing CI exercises the `sudo`/`root` paths (runners deploy as a passwordless-sudo user), so both paths stay covered.

## Follow-up (not in this PR)
- A rootless CI leg (deploy as a no-sudo user) to guard the `PRIV=none` path directly.
- Ties into the fleet identity work — `agent-provision.sh` is the natural place to inject per-agent identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)