### PR TITLE
ci: rootless agent-space verification leg (#99)

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -5,6 +5,7 @@ LICENSE
 Dockerfile.test
 Dockerfile.alpine
 Dockerfile.rhel
+Dockerfile.rootless
 entrypoint.sh
 .github/**
 scripts/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,14 +218,61 @@ jobs:
               echo "=== All core tools present ==="
             '
 
+  # ── Rootless: verify sudo-less agent-space deploy (#99) ─────────────────────
+  # Builds Dockerfile.rootless: a root phase provisions a no-sudo `agent` user
+  # (via scripts/agent-provision.sh), then `chezmoi apply` runs as that agent.
+  # The build fails if apply errors, so a green build already proves the
+  # PRIV=none path; this step re-asserts the outcome (dotfiles + core tools).
+  # Alpine base — apk, not Homebrew — isolates the privilege path from the
+  # Homebrew-needs-root wrinkle on glibc.
+  rootless:
+    name: rootless
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+
+      - name: Build rootless agent-space image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
+        with:
+          context: .
+          file: Dockerfile.rootless
+          load: true
+          tags: dotfiles-rootless:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            CHEZMOI_BRANCH=${{ github.head_ref || github.ref_name }}
+
+      - name: Verify dotfiles deployed as the sudo-less agent
+        run: |
+          docker run --rm --entrypoint /bin/su dotfiles-rootless:test \
+            agent -s /bin/sh -c '
+              set -e
+              echo "=== Verifying rootless agent deploy ==="
+              [ -f "$HOME/.zshrc" ] && echo "✓ ~/.zshrc laid down" || { echo "✗ ~/.zshrc MISSING"; exit 1; }
+              for tool in zsh git curl jq fzf bat rg; do
+                if command -v "$tool" >/dev/null 2>&1; then
+                  echo "✓ $tool"
+                else
+                  echo "✗ $tool MISSING" && exit 1
+                fi
+              done
+              echo "=== rootless deploy verified ==="
+            '
+
   # ── Linux aggregator: required status check ─────────────────────────────────
   # Branch protection on `main` requires a status check named `linux`. This job
   # reports success only when every matrix leg AND the distro-specific jobs
-  # (alpine, rhel) pass, preserving the contract while letting the matrix and
-  # distro list expand independently of branch-protection config.
+  # (alpine, rhel, rootless) pass, preserving the contract while letting the
+  # matrix and distro list expand independently of branch-protection config.
   linux:
     name: linux
-    needs: [profiles, alpine, rhel]
+    needs: [profiles, alpine, rhel, rootless]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -234,7 +281,8 @@ jobs:
           profiles='${{ needs.profiles.result }}'
           alpine='${{ needs.alpine.result }}'
           rhel='${{ needs.rhel.result }}'
-          echo "profiles: $profiles  alpine: $alpine  rhel: $rhel"
+          rootless='${{ needs.rootless.result }}'
+          echo "profiles: $profiles  alpine: $alpine  rhel: $rhel  rootless: $rootless"
           if [[ "$profiles" != "success" ]]; then
             echo "::error::At least one profile matrix leg did not succeed (result=$profiles)"
             exit 1
@@ -245,6 +293,10 @@ jobs:
           fi
           if [[ "$rhel" != "success" ]]; then
             echo "::error::RHEL job did not succeed (result=$rhel)"
+            exit 1
+          fi
+          if [[ "$rootless" != "success" ]]; then
+            echo "::error::Rootless agent-space job did not succeed (result=$rootless)"
             exit 1
           fi
 

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -1,0 +1,46 @@
+FROM alpine:3.22
+
+# Rootless agent-space verification (#99).
+#
+# Proves the two-phase model: a root/provisioning phase prepares the machine,
+# then an UNPRIVILEGED agent (no sudo) deploys dotfiles with `chezmoi apply`.
+# Alpine is used deliberately — apk (not Homebrew) means no root-requiring
+# installer in the apply phase, so this isolates the PRIV=none code path.
+
+# Bare minimum for the root phase to run agent-provision.sh (it installs the rest).
+RUN apk add --no-cache bash curl
+
+# ── Phase 1 (root): provision the agent space ────────────────────────────────
+# agent-provision.sh installs system + core tools, creates the `agent` user with
+# a zsh login shell, and deliberately does NOT grant it sudo.
+COPY scripts/agent-provision.sh /usr/local/bin/agent-provision.sh
+RUN chmod +x /usr/local/bin/agent-provision.sh && agent-provision.sh agent
+
+# Assert the agent genuinely has no sudo — otherwise this test proves nothing.
+RUN if su - agent -c 'command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null'; then \
+      echo "✗ agent unexpectedly has passwordless sudo — test would not exercise PRIV=none" >&2; \
+      exit 1; \
+    else echo "✓ agent has no sudo (PRIV=none will be exercised)"; fi
+
+ARG CHEZMOI_BRANCH=main
+
+# ── Phase 2 (agent, NO sudo): deploy dotfiles ────────────────────────────────
+USER agent
+WORKDIR /home/agent
+ENV PATH="/home/agent/.local/bin:${PATH}"
+
+# chezmoi installs to ~/.local/bin with no root needed.
+RUN sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+
+# init + apply as the sudo-less agent. The bootstrap must detect PRIV=none,
+# skip privileged steps, and still lay down the dotfiles.
+# --exclude=encrypted: age key is never present in CI (same as the other images).
+RUN chezmoi init --no-tty --branch "${CHEZMOI_BRANCH}" Jobikinobi \
+ && chezmoi apply --no-tty --exclude=encrypted
+
+# Root again only for the entrypoint (parity with the other images).
+USER root
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+EXPOSE 22
+ENTRYPOINT ["/entrypoint.sh"]

--- a/run_once_before_install-tailscale.sh.tmpl
+++ b/run_once_before_install-tailscale.sh.tmpl
@@ -6,6 +6,14 @@ set -e
 # Runs early (BEFORE phase) so the rest of the bootstrap has network identity.
 # ══════════════════════════════════════════════════════════════════════════════
 
+# Installing/administering a system VPN daemon needs privilege. A sudo-less
+# agent-space (#99) skips this entirely — networking is the provisioning phase's
+# job. (Tailscale is also being retired in favour of Netbird per ADR-002.)
+if [ "$(id -u)" -ne 0 ] && ! { command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; }; then
+  echo "→ Unprivileged agent-space — skipping Tailscale install/setup"
+  exit 0
+fi
+
 if ! command -v tailscale &>/dev/null; then
 {{- if eq .chezmoi.os "darwin" }}
   echo "→ Tailscale: install via 'brew install --cask tailscale' or Brewfile"

--- a/scripts/agent-provision.sh
+++ b/scripts/agent-provision.sh
@@ -71,6 +71,11 @@ case "$OS_FAMILY" in
     fi
     apk update -q
     apk add --no-cache bash build-base ca-certificates curl file git gnupg procps shadow sudo zsh
+    # Core CLI tools too: a sudo-less agent can't apk these itself during apply
+    # (the brewfile step's apk fallback is skipped under PRIV=none), so the root
+    # phase must provide them. Mirrors APK_CORE_PACKAGES in install-brewfile.
+    apk add --no-cache age bat direnv eza fd fzf go helix jq nnn ripgrep 2>/dev/null \
+      || echo "  ⚠ some core apk tools unavailable in this Alpine version — continuing"
     ;;
   rhel)
     PKG_MGR=$(command -v dnf || command -v yum)
@@ -116,7 +121,12 @@ fi
 # ── 3. Shared Homebrew (glibc only; Alpine uses apk in the apply phase) ───────
 if [ "$OS_FAMILY" != "alpine" ]; then
   if [ ! -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
-    echo "→ Installing Homebrew (shared prefix) as ${AGENT_USER}"
+    # Pre-create and hand ownership of the prefix to the agent so the installer
+    # runs without root — the standard rootless-Homebrew pattern. Without this,
+    # Homebrew's installer shells out to sudo, which a sudo-less agent lacks.
+    mkdir -p /home/linuxbrew/.linuxbrew
+    chown -R "$AGENT_USER" /home/linuxbrew
+    echo "→ Installing Homebrew (shared prefix, agent-owned) as ${AGENT_USER}"
     su - "$AGENT_USER" -c 'NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
   fi
   cat > /etc/profile.d/linuxbrew.sh <<'PROFILE'


### PR DESCRIPTION
Follow-up to #103 — adds the CI leg that guards the sudo-less deploy path directly.

## Why
#103 shipped the `PRIV=none` code but CI runners deploy as a passwordless-sudo user, so nothing exercised the new path. This leg builds a genuinely sudo-less agent and proves `chezmoi apply` succeeds.

## What
- **`Dockerfile.rootless`** — Alpine two-phase build:
  1. **root:** `scripts/agent-provision.sh agent` (system + core tools, creates `agent`, **no sudo**)
  2. **agent (no sudo):** `chezmoi init --apply`
  It asserts the agent actually lacks sudo, so the test can't pass for the wrong reason. Alpine (apk, not Homebrew) isolates the privilege path from the Homebrew-needs-root wrinkle on glibc.
- **`ci.yml`** — new `rootless` job, wired into the required `linux` aggregator.
- **`agent-provision.sh`** — Alpine branch installs core CLI tools (a sudo-less agent can't apk them during apply); glibc brew install pre-owns the prefix so it needs no root.
- **`run_once_before_install-tailscale`** — skip under `PRIV=none`. This was the one remaining apply-path script that assumed sudo (it `curl … | sh`'d the Tailscale installer, which shells out to `sudo apk`). Also aligns with ADR-002 retiring Tailscale.

## Verification
Locally: rendered bootstrap as non-root with failing sudo → `PRIV=none`, skips, exit 0 (from #103). Full Docker build couldn't run locally (no daemon) — this CI leg *is* the end-to-end test. On green, closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)