### PR TITLE
fix(zprofile): per-OS Homebrew path, guarded (#62)

### DIFF
--- a/dot_zprofile
+++ b/dot_zprofile
@@ -1,6 +1,0 @@
-
-eval "$(/opt/homebrew/bin/brew shellenv zsh)"
-
-# Added by OrbStack: command-line tools and integration
-# This won't be added again if you remove it.
-source ~/.orbstack/shell/init.zsh 2>/dev/null || :

--- a/dot_zprofile.tmpl
+++ b/dot_zprofile.tmpl
@@ -1,0 +1,18 @@
+{{ if eq .chezmoi.os "darwin" -}}
+# Homebrew (macOS): Apple Silicon prefix first, fall back to Intel.
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
+# Added by OrbStack: command-line tools and integration
+source ~/.orbstack/shell/init.zsh 2>/dev/null || :
+{{- else -}}
+# Homebrew (Linux): only if Linuxbrew is present. Guarded so a brew-less host
+# (e.g. Alpine/musl, where core tools come from apk) doesn't throw
+# "no such file or directory: /opt/homebrew/bin/brew" on every login — #62.
+if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi
+{{- end }}


### PR DESCRIPTION
Closes #62.

## Bug
`dot_zprofile` hardcoded the macOS brew path **and wasn't a template**, so it shipped verbatim to every Linux machine:
```
eval "$(/opt/homebrew/bin/brew shellenv zsh)"
```
On Linux that path doesn't exist → `/.zprofile:2: no such file or directory: /opt/homebrew/bin/brew` on **every login shell**.

## Fix
Convert to `dot_zprofile.tmpl`:
- **macOS:** `/opt/homebrew` (Apple Silicon) → `/usr/local` (Intel) fallback; keep OrbStack init
- **Linux:** `/home/linuxbrew/.linuxbrew/bin/brew`, only when it exists
- **brew-less hosts** (Alpine/musl, where core tools come from apk) no-op cleanly — no error

## Verification
Reproduced and fixed in a live rootless agent container on real Docker: the `/opt/homebrew` login error was present before, gone after. Rebuilding the CI rig from this branch confirms chezmoi renders the guarded Linux form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)