### PR TITLE
fix(bashrc): per-OS Homebrew PATH injection (#100, #56)

### DIFF
--- a/dot_bashrc
+++ b/dot_bashrc
@@ -1,2 +1,0 @@
-export PATH="/opt/homebrew/opt/postgresql@15/bin:$PATH"
-. "$HOME/.cargo/env"

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -1,0 +1,21 @@
+{{ if eq .chezmoi.os "darwin" -}}
+# Homebrew on PATH (macOS): Apple Silicon prefix first, fall back to Intel.
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
+# postgresql@15 keg (macOS) — only if the keg is actually installed.
+[ -d /opt/homebrew/opt/postgresql@15/bin ] && export PATH="/opt/homebrew/opt/postgresql@15/bin:$PATH"
+{{- else -}}
+# Homebrew on PATH (Linux): only when Linuxbrew is present, so a brew-less host
+# (e.g. Alpine/musl) is a clean no-op. This is the bash side of "auto-inject
+# brew into the shell" — the zsh side lives in .zprofile / .zshrc (#100).
+if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi
+{{- end }}
+
+# Rust — guarded so a fresh machine without rustup doesn't error on every shell.
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"


### PR DESCRIPTION
Closes #100. Closes #56.

## #100 — auto-inject brew into the shell
The zsh side was already handled (`.zprofile` + `.zshrc` do per-OS guarded `brew shellenv`), but **bash had none** — `dot_bashrc` never put brew on PATH, hardcoded a macOS postgres keg path, and sourced `~/.cargo/env` unguarded (errors on a fresh machine).

Convert `dot_bashrc` → `dot_bashrc.tmpl` mirroring the zsh side:
- **macOS:** `/opt/homebrew` → `/usr/local` fallback; postgres keg only if present
- **Linux:** `/home/linuxbrew`, only when the binary exists (Alpine/musl = clean no-op)
- guard the cargo env source

## #56 — install brew directly, not via chezmoi
Already satisfied: `run_once_before_install-homebrew` curls the installer directly (chezmoi runs a script, it doesn't 'download and deploy brew'), and `scripts/agent-provision.sh` (#99) installs brew in the root phase. Combined with this PATH auto-injection, the recurring brew+PATH problem is closed.

## Verification
Sourced the rendered Linux `.bashrc` on a real Debian box (jdebian): `✓ brew on PATH: /home/linuxbrew/.linuxbrew/bin/brew`. Both OS branches render + `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)