### PR TITLE
feat: add zoxide (#60); remove mac-studio projects alias (#61)

### DIFF
--- a/dot_Brewfile.core
+++ b/dot_Brewfile.core
@@ -20,6 +20,7 @@ brew "nnn"          # file manager
 brew "powerlevel10k" # zsh prompt theme
 brew "ripgrep"      # grep replacement
 brew "uv"           # Python package manager
+brew "zoxide"       # smarter cd (z / zi)
 brew "lazyssh"
 # ── Git tooling ─────────────────────────────────────────────────────────────
 brew "git"

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -173,6 +173,9 @@ esac
 # direnv
 command -v direnv &>/dev/null && eval "$(direnv hook zsh)"
 
+# zoxide — smarter cd (provides `z` / `zi`)
+command -v zoxide &>/dev/null && eval "$(zoxide init zsh)"
+
 # Suppress update nags
 export DISABLE_AUTOUPDATER=1
 export NO_UPDATE_NOTIFIER=1
@@ -235,7 +238,6 @@ alias gst='git status' glog='git log --oneline --graph --decorate'
 # 12. UTILITY ALIASES
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-alias projects='cd /Volumes/HOLE-RAID-DRIVE/Projects'
 alias venva='source .venv/bin/activate'
 alias secure-reboot='sudo fdesetup authrestart'
 alias restart-screensharing='sudo launchctl kickstart -k system/com.apple.screensharing'

--- a/run_once_after_install-brewfile.sh.tmpl
+++ b/run_once_after_install-brewfile.sh.tmpl
@@ -60,6 +60,7 @@ if ! command -v brew >/dev/null 2>&1; then
       jq             # JSON processor
       nnn            # file manager
       ripgrep        # grep replacement
+      zoxide         # smarter cd
       zsh            # login shell
     )
     # Privilege-aware (#99): root runs apk directly; a self-deploy uses

--- a/scripts/agent-provision.sh
+++ b/scripts/agent-provision.sh
@@ -74,7 +74,7 @@ case "$OS_FAMILY" in
     # Core CLI tools too: a sudo-less agent can't apk these itself during apply
     # (the brewfile step's apk fallback is skipped under PRIV=none), so the root
     # phase must provide them. Mirrors APK_CORE_PACKAGES in install-brewfile.
-    apk add --no-cache age bat direnv eza fd fzf go helix jq nnn ripgrep 2>/dev/null \
+    apk add --no-cache age bat direnv eza fd fzf go helix jq nnn ripgrep zoxide 2>/dev/null \
       || echo "  ⚠ some core apk tools unavailable in this Alpine version — continuing"
     ;;
   rhel)


### PR DESCRIPTION
Two quick wins.

## #61 — remove dead mac-studio alias
`alias projects='cd /Volumes/HOLE-RAID-DRIVE/Projects'` pointed at a mac-studio RAID volume — a non-functional, annoying alias on every other machine. Removed.

## #60 — add zoxide
- `dot_Brewfile.core`: `brew "zoxide"`
- `dot_zshrc.tmpl`: `eval "$(zoxide init zsh)"` alongside the direnv/fnm hooks — active out of the gate (`z` / `zi`)
- Alpine parity: added to the apk fallback (`install-brewfile`) and `agent-provision.sh`; verified `zoxide 0.9.7-r0` is in Alpine 3.22 community

Closes #60. Closes #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)