### PR TITLE
docs(homelab): NFS corpus mount + Samba Time Machine runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ dotfiles/
 ├── entrypoint.sh                      # Tailscale + sshd startup
 ├── com.jth.mac-save.plist             # macOS launchd auto-save
 ├── docs/                              # Project documentation
+│   └── homelab/timemachine/           #   → Samba Time Machine backup runbook
 └── scripts/                           # Legacy/utility scripts
 ```
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,6 +31,14 @@ Policy docs that govern how this repo is used day-to-day.
 |---|---|
 | [`architecture.md`](architecture.md) | System topology: tailnet, headscale, Caddy, services |
 
+## Homelab
+
+| File | Summary |
+|---|---|
+| [`homelab/README.md`](homelab/README.md) | Homelab goal, architectural pins, PVE hub + Mac thin-client plan |
+| [`homelab/nfs-corpus-mount.md`](homelab/nfs-corpus-mount.md) | Mount the `corpus` NFS drive (`/data/corpus` → `/Volumes/corpus`): LAN Bonjour, off-LAN NetBird, fallbacks |
+| [`homelab/recovery.md`](homelab/recovery.md) | Homelab recovery procedures |
+
 ## ADR (Architecture Decision Records)
 
 | File | Decision |

--- a/docs/homelab/README.md
+++ b/docs/homelab/README.md
@@ -65,6 +65,33 @@ The Headscale rollout details, current node inventory, and the cutover playbook 
   (DHCP — should be reserved at the router). User `jth`, key-only sshd,
   passwordless sudo. 2c/2GB/8GB. Created 2026-05-20.
 
+### Pinned LAN addressing — `10.0.0.0/24` fleet (2026-07-23)
+
+The Incus host and the corpus NFS server sit on the **`10.0.0.0/24`** LAN
+(distinct from the PVE `192.168.68.0/24` net above). These addresses are now
+**DHCP-reserved at the router** so they no longer drift on lease renewal —
+which is what makes the LAN-primary rule (pin #2) safe to rely on for these
+hosts. Reservations verified holding 2026-07-23.
+
+| Host             | LAN (reserved)   | NetBird (`*.netbird.hole`) | Notes                                            |
+|------------------|------------------|----------------------------|--------------------------------------------------|
+| Incus host       | `10.0.0.33`      | `100.80.12.6`              | `incusd` binds `core.https_address :8443` (all ifaces) → reachable on **both** LAN and NetBird. |
+| nfs (corpus)     | `10.0.0.36`      | `100.80.245.142`           | Proxmox CT 114; exports `/data/corpus`. See [`nfs-corpus-mount.md`](nfs-corpus-mount.md). |
+| MacBook Air      | `10.0.0.4`       | `100.80.139.213`           | This workstation (`en0`). Was `.34` pre-reservation. |
+
+**Incus remote = LAN-primary, NetBird fallback** (matches pin #2). The Mac's
+default Incus remote points at the LAN IP; the overlay path is kept as a named
+fallback:
+
+| Remote          | URL                            | Path     |
+|-----------------|--------------------------------|----------|
+| `incus` *(default)* | `https://10.0.0.33:8443`   | LAN — `route get 10.0.0.33` → `en0`, ~130 ms `incus list` |
+| `incus2`        | `https://incus.netbird.hole:8443` | NetBird overlay — for off-LAN |
+
+Switch paths with `incus remote switch incus` / `incus remote switch incus2`.
+No reverse DNS (PTR) zone exists in Pi-hole for `10.0.0.0/24` yet — forward
+`.hole` names resolve, but `host 10.0.0.33` returns NXDOMAIN (cosmetic).
+
 ### SSH key catalog (managed by chezmoi)
 
 | Key file (deployed)              | Reaches                          | In dotfiles? |
@@ -86,10 +113,26 @@ fine — different prefix. Public keys are reconstructable on demand:
 | Location                                          | Audience          | Deployed? |
 |---------------------------------------------------|-------------------|-----------|
 | `docs/homelab/` (this file)                       | future-me at repo | no        |
+| `docs/homelab/timemachine/` (Samba TM runbook)    | future-me at repo | no        |
 | `~/.local/share/infra/` (from `dot_local/...`)    | future-me on Mac  | yes (enc) |
 | `~/Documents/__RECOVERY__/` (transient)           | bootstrap         | manual    |
 
 ## Setup log
+
+### 2026-07-06
+
+1. **Stood up network Time Machine** on `jdebian` (Samba 4.22, dedicated ext4
+   disk at `/mnt/timemachine`, unencrypted over SMB). Full runbook:
+   [`timemachine/README.md`](timemachine/README.md).
+2. **Root cause of prior failures found:** `force user = nobody` prevented macOS
+   from owning the sparsebundle → "backup disk image could not be created."
+   Fixed by letting `jth` own the backups + `fruit:nfs_aces = no` +
+   `fruit:advertise_fullsync = true`. Verified against `mbentley` and FreeBSD
+   Foundation configs.
+3. **Disk hygiene:** mounted backup disk by **UUID** with `nofail` (device
+   letters had swapped `sda`↔`sdb` on a reboot); grew it 300G→500G online
+   (`growpart` + `resize2fs`); capped `time machine max size` below disk size.
+4. **Confirmed working:** `<ComputerName>.sparsebundle` created and growing.
 
 ### 2026-05-20
 

--- a/docs/homelab/nfs-corpus-mount.md
+++ b/docs/homelab/nfs-corpus-mount.md
@@ -1,0 +1,93 @@
+# Mounting the `corpus` NFS drive
+
+How to mount the shared **`/data/corpus`** NFS export (legal corpus + working
+data) on a Mac workstation. Repo-internal runbook — filtered out of chezmoi
+deploy by `.chezmoiignore: docs/**`.
+
+## What / where
+
+| Fact | Value |
+|---|---|
+| Export | `/data/corpus (rw,sync,insecure,no_subtree_check,no_root_squash)` |
+| Allowed nets | `10.0.0.0/24` (LAN), `100.80.0.0/16` (NetBird) |
+| Server | Proxmox LXC **container 114 "nfs"** on `pve` |
+| LAN address | `10.0.0.36` / `nfs.local` |
+| NetBird address | `100.80.245.142` |
+| Mounts at | `/Volumes/corpus` |
+
+The container advertises the export over **Bonjour/mDNS** (`avahi-daemon`,
+`_nfs._tcp` port 2049), so it shows up in **Finder → Network as "corpus on
+nfs"** — clicking it mounts with no sudo. The CLI equivalents below do the same
+thing without leaving the terminal.
+
+## Mount (on the home LAN — the normal case)
+
+```sh
+osascript -e 'mount volume "nfs://nfs.local/data/corpus"'
+```
+
+Bonjour discovery is link-local, so `nfs.local` only resolves on the home LAN
+(`10.0.0.0/24`). This is the everyday path.
+
+Verify:
+
+```sh
+mount | grep corpus
+#   nfs.local:/data/corpus on /Volumes/corpus (nfs, nodev, nosuid, mounted by <you>)
+df -h /Volumes/corpus
+```
+
+## Mount (off-LAN, via NetBird)
+
+`nfs.local` won't resolve off the home network — address the NetBird IP directly:
+
+```sh
+osascript -e 'mount volume "nfs://100.80.245.142/data/corpus"'
+```
+
+## Fallback: classic `mount_nfs`
+
+The export sets `insecure` specifically so the Finder/NetFS mount works without a
+reserved source port. If you instead mount with the default-`secure` path (e.g.
+`mount_nfs` without NetFS), pass `resvport`:
+
+```sh
+mkdir -p /Volumes/corpus
+mount_nfs -o rw,resvport 10.0.0.36:/data/corpus /Volumes/corpus
+```
+
+## Unmount
+
+```sh
+umount /Volumes/corpus
+# or, if the server dropped and it's wedged:
+diskutil unmount force /Volumes/corpus
+```
+
+## Troubleshooting
+
+- **"corpus on nfs" not in Finder → Network / `nfs.local` won't resolve** — you're
+  off-LAN (Bonjour is link-local). Use the NetBird IP form above.
+- **Mount hangs / "Operation timed out"** — the `nfs` container (CT 114) or `pve`
+  is down, or you're on neither the LAN nor NetBird. Confirm reachability:
+  `ping nfs.local` (LAN) or `ping 100.80.245.142` (NetBird).
+- **`Permission denied` / `RPC: Authentication error`** — you tried a `secure`
+  mount without `resvport`. Use the Bonjour/NetFS path, or add `resvport` as
+  shown in the fallback.
+- **Do NOT use autofs.** macOS Tahoe (26) blocks autofs direct maps into
+  `/Volumes` (`automount: .../Volumes/corpus: mountpoint unavailable`). The old
+  `/etc/auto_nfs` + `/-  auto_nfs` lines were removed on purpose.
+
+## Optional: shell shortcut
+
+Not wired by default. To make mounting one word, add to your shell rc:
+
+```sh
+alias corpus='osascript -e '\''mount volume "nfs://nfs.local/data/corpus"'\'' && open /Volumes/corpus'
+```
+
+## See also
+
+- Server-side export config and Bonjour/avahi setup live with the `nfs`
+  container (CT 114) on `pve`.
+- Homelab topology and addressing: [`README.md`](README.md).

--- a/docs/homelab/timemachine/README.md
+++ b/docs/homelab/timemachine/README.md
@@ -1,0 +1,208 @@
+# Time Machine → Samba on `jdebian` — Runbook
+
+How to stand up (or rebuild) the network Time Machine backup target on the
+`jdebian` VM, and — more importantly — every trap that cost us hours the first
+time. If future-you is staring at "The backup disk image could not be created,"
+**jump to [Troubleshooting](#troubleshooting)**.
+
+- **Server:** `jdebian` — Debian 13, Samba 4.22, a dedicated ext4 disk mounted
+  at `/mnt/timemachine`.
+- **Reach:** LAN `10.0.0.26` (fast, use when co-located) or NetBird
+  `jdebian.netbird.hole` / `100.80.247.107` (off-LAN).
+- **Client:** macOS, backing up unencrypted over SMB.
+- **Companion files:** [`smb.conf`](smb.conf) (verbatim working config),
+  [`references.md`](references.md).
+
+---
+
+## TL;DR — the four things that actually made it work
+
+1. **Mount the backup disk by UUID in `/etc/fstab` with `nofail`.** Linux device
+   letters (`sda`/`sdb`) swap across reboots; a name-based mount silently grabs
+   the wrong disk or vanishes. Ours flipped `sda1`→`sdb1` on a reboot mid-project.
+2. **Let the real user own the backups — NO `force user = nobody`.** This was the
+   killer. `nobody` can't take ownership of the sparsebundle → `Permission denied`
+   → "backup disk image could not be created."
+3. **`fruit:nfs_aces = no`** (+ `fruit:advertise_fullsync = true`,
+   `fruit:zero_file_id = yes`) in `[global]`. Stops macOS from trying ownership
+   changes the server will reject.
+4. **The destination lives on the Mac, not the server.** A perfect `smb.conf`
+   backs up nothing until `tmutil setdestination` is run on the Mac.
+
+---
+
+## Server setup (from scratch)
+
+### 1. Install Samba
+```bash
+sudo apt update
+sudo apt install -y samba
+smbd --version   # need >= 4.8
+```
+
+### 2. Prepare the backup disk — **by UUID**
+```bash
+# format a dedicated disk (DESTROYS the disk — be sure of the device)
+sudo mkfs.ext4 /dev/sdX1
+
+# find its stable UUID
+lsblk -f            # note the UUID of the backup partition
+
+sudo mkdir -p /mnt/timemachine
+
+# persistent mount by UUID, nofail so a missing disk never blocks boot
+echo "UUID=<PASTE-UUID> /mnt/timemachine ext4 defaults,nofail 0 2" | sudo tee -a /etc/fstab
+sudo systemctl daemon-reload
+sudo mount /mnt/timemachine
+findmnt /mnt/timemachine     # confirm it's the RIGHT disk
+```
+
+### 3. Ownership — the real user owns it (not `nobody`)
+```bash
+# jth is the Samba/backup user; the share connects AS this user
+sudo chown jth:jth /mnt/timemachine
+sudo chmod 0770 /mnt/timemachine
+```
+
+### 4. Samba user
+```bash
+sudo smbpasswd -a jth     # sets the SMB password (separate from the Linux one)
+sudo smbpasswd -e jth     # ensure enabled
+sudo pdbedit -L -v jth | grep 'Account Flags'   # want [U ...], NOT [D ...]
+# jth must be in the sambashare group (valid users = @sambashare):
+id jth | grep -o sambashare || sudo usermod -aG sambashare jth
+```
+
+### 5. `smb.conf`
+Install the companion [`smb.conf`](smb.conf) to `/etc/samba/smb.conf`
+(back up any existing one first). Then:
+```bash
+sudo testparm -s            # must say "Loaded services file OK"
+sudo systemctl restart smbd nmbd
+sudo systemctl enable smbd nmbd
+```
+
+### 6. Avahi advertisement (LAN discovery only — see note)
+`/etc/avahi/services/samba.service`:
+```xml
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+    <name replace-wildcards="yes">%h</name>
+    <service><type>_smb._tcp</type><port>445</port></service>
+    <service>
+        <type>_adisk._tcp</type><port>9</port>
+        <txt-record>sys=waMa=0,adVF=0x100</txt-record>
+        <txt-record>dk0=adVN=timemachine,adVF=0x82</txt-record>
+    </service>
+</service-group>
+```
+```bash
+sudo systemctl restart avahi-daemon
+```
+> **Note:** mDNS/Bonjour is link-local multicast and **does not cross the NetBird
+> overlay**. Over NetBird the share will NOT auto-appear in Finder — you connect
+> manually (below). Avahi only helps same-LAN discovery.
+
+### 7. Server-side sanity checks
+```bash
+# can the connecting user write?
+sudo -u jth bash -c 'touch /mnt/timemachine/.wtest && echo OK && rm /mnt/timemachine/.wtest'
+
+# capability test — this is EXACTLY what Time Machine does.
+# Run on a Mac with the share mounted; it must succeed and create band files:
+hdiutil create -size 10g -type SPARSEBUNDLE -fs HFS+J -volname t \
+  /Volumes/timemachine/t.sparsebundle && rm -rf /Volumes/timemachine/t.sparsebundle
+```
+
+---
+
+## Mac setup (this is where backups are actually enabled)
+
+```bash
+# 1. mount + save creds to Keychain (LAN IP is faster for the first full backup)
+#    Finder → Cmd-K → smb://jth@jdebian.netbird.hole/timemachine   (or smb://10.0.0.26/timemachine)
+
+# 2. register the destination (unencrypted — see key-custody note)
+sudo tmutil setdestination -a "smb://jth@jdebian.netbird.hole/timemachine"
+tmutil destinationinfo        # should now list it
+
+# 3. start + watch
+sudo tmutil startbackup
+tmutil status
+```
+Confirm it's real, server-side:
+```bash
+ssh jth@jdebian.netbird.hole \
+  'sudo find /mnt/timemachine -maxdepth 2 -iname "*.sparsebundle"; df -h /mnt/timemachine'
+# you want a "<ComputerName>.sparsebundle" that GROWS.
+```
+
+---
+
+## Growing the disk later (done once already, 300G → 500G)
+
+Disk was expanded in the hypervisor; inside the guest, online-grow it:
+```bash
+sudo apt install -y cloud-guest-utils     # for growpart, if missing
+sudo growpart /dev/sdX 1                   # grow partition into new free space
+sudo resize2fs /dev/sdX1                    # online-grow ext4 (safe while mounted)
+df -h /mnt/timemachine
+# then optionally raise `fruit:time machine max size` in smb.conf (keep < disk)
+```
+
+---
+
+## Encryption / key custody ⚠️
+
+We run this **unencrypted** *on purpose*. History: an earlier encrypted network
+backup became unrecoverable because the sparsebundle password lived **only in the
+Mac's login Keychain**, which was destroyed when the Mac was wiped — "backed up
+fine, couldn't decrypt, data lost."
+
+- If you ever re-enable **encrypted** Time Machine: **record the password in a
+  password manager BEFORE the first backup**, and verify you can decrypt it from
+  a *different* Mac (no shared Keychain) before trusting it.
+- Unencrypted trade-off: anyone who can read `/mnt/timemachine` (or the disk) can
+  read everything on the Mac. If you want at-rest protection without the
+  key-loss risk, use **LUKS on the server** with a passphrase you control.
+
+**Always verify a restore (read data back) before relying on a backup.**
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| **"The backup disk image could not be created"** / `hdiutil ... Permission denied` | `force user = nobody` — `nobody` can't own the sparsebundle | Remove `force user`/`force group`; `chown jth:jth /mnt/timemachine`; set `fruit:nfs_aces = no` in `[global]` |
+| `Failed to mount destination` (backupd Code 32) | destination registered but not truly mounted / cred issue | Re-mount in Finder (save to Keychain), then `sudo tmutil setdestination -a smb://…` |
+| Backup never starts; `tmutil status` Running=0 | **no destination configured on the Mac** | `sudo tmutil setdestination -a smb://user@host/timemachine` |
+| Share not visible in Finder / TM disk list | mDNS doesn't cross NetBird overlay | Connect manually: Finder → ⌘K → `smb://user@host/timemachine` |
+| Backup disk gone after a reboot | fstab used device name, or not in fstab | Mount by **UUID** with `nofail` (see step 2) |
+| `mds_init_ctx ... vfs_ChDir ... Permission denied` in samba logs | `spotlight = yes` (mds can't enter the share dir) | `spotlight = no` — TM doesn't need it |
+| Backup fills disk / corrupts | `fruit:time machine max size` > physical disk | Cap it **below** the disk size |
+| Auth fails from Mac | Samba pw not set/enabled (separate from Linux pw) | `sudo smbpasswd -a jth && sudo smbpasswd -e jth` |
+
+### Useful diagnostics
+```bash
+# server: live samba log + errors
+sudo tail -f /var/log/samba/log.*        # watch during a backup
+sudo grep -riE 'error|denied|no space' /var/log/samba/
+
+# mac: what backupd thinks
+tmutil status ; tmutil destinationinfo ; tmutil latestbackup
+```
+
+---
+
+## Why it kept failing (post-mortem)
+
+The disk/mount/space fixes were necessary but never the blocker. The real
+failure was **ownership**: our share used `force user = nobody`, and with
+`fruit:nfs_aces = yes` (the Samba default) macOS tried to set ownership on the
+new sparsebundle. `nobody` isn't allowed to do that, so Samba returned
+`Permission denied` and macOS reported "The backup disk image could not be
+created." Both the `mbentley` and FreeBSD Foundation reference configs avoid
+`nobody` entirely and let the connecting user own its backups — matching that,
+plus `fruit:nfs_aces = no`, is what fixed it. See [`references.md`](references.md).

--- a/docs/homelab/timemachine/references.md
+++ b/docs/homelab/timemachine/references.md
@@ -1,0 +1,39 @@
+# References — Samba Time Machine
+
+The three sources that actually mattered, and what each contributed. All three
+independently confirm the key fixes in the runbook.
+
+## Primary
+
+- **mbentley/docker-timemachine** — <https://github.com/mbentley/docker-timemachine>
+  Proven, widely-used working config. Source of `fruit:nfs_aces = no`,
+  `fruit:zero_file_id = yes`, `fruit:advertise_fullsync = true`, and the pattern
+  of a **dedicated owning user** (not `nobody`).
+
+- **FreeBSD Foundation Journal — "Samba-based Time Machine backups"**
+  <https://freebsdfoundation.org/our-work/journal/browser-based-edition/storage-and-filesystems/samba-based-time-machine-backups/>
+  Authoritative `vfs_fruit` write-up. Its share uses `valid users = %U` +
+  `path = .../%U` with **no `force user`** — the connecting user owns their own
+  backup. Confirmed that our `force user = nobody` was the outlier causing the
+  `Permission denied` on disk-image creation. Also has `fruit:nfs_aces = no` and
+  `fruit:advertise_fullsync = true` in `[global]`.
+
+## Supporting
+
+- **Samba `vfs_fruit` man page** — `man vfs_fruit` (or
+  <https://www.samba.org/samba/docs/current/man-html/vfs_fruit.8.html>)
+  Canonical meaning of every `fruit:*` option, including `nfs_aces` (default
+  `yes` lets the client set POSIX perms via NFS ACEs — the thing that fought
+  `force user = nobody`).
+
+- **Generic Ubuntu/Samba TM guide** (the "practical low-cost" walkthrough)
+  Good for the baseline share/user/size-limit steps, but note: it enables
+  Spotlight (we disabled it — caused `mds_init_ctx ... Permission denied` noise)
+  and it does NOT include the `nfs_aces`/`advertise_fullsync`/no-`force user`
+  fixes, so following it alone reproduces the failure.
+
+## The one-line lesson
+
+> Every reputable config lets the **real authenticated user own the backup
+> files**. `force user = nobody` + `fruit:nfs_aces = yes` (the default) is what
+> breaks sparsebundle creation with "The backup disk image could not be created."

--- a/docs/homelab/timemachine/smb.conf
+++ b/docs/homelab/timemachine/smb.conf
@@ -1,0 +1,79 @@
+# =============================================================================
+# Working Samba config for macOS Time Machine over SMB — jdebian
+# Captured verbatim from /etc/samba/smb.conf on the day it first worked.
+#
+# The three settings that made disk-image creation finally succeed (see README):
+#   - fruit:nfs_aces = no
+#   - NO `force user = nobody` in [timemachine]  (let the real user own backups)
+#   - fruit:advertise_fullsync = true
+# =============================================================================
+
+[global]
+    # Server identification
+    workgroup = WORKGROUP
+    server string = jdebian Time Machine
+    netbios name = JDEBIAN
+
+    # Security
+    security = user
+    map to guest = never
+
+    # macOS compatibility (SMB2/3 only)
+    server min protocol = SMB2
+    server max protocol = SMB3
+
+    vfs objects = catia fruit streams_xattr
+    fruit:aapl = yes
+    fruit:advertise_fullsync = true
+    fruit:metadata = stream
+    fruit:model = MacSamba
+    fruit:posix_rename = yes
+    fruit:veto_appledouble = no
+    fruit:wipe_intentionally_left_blank_rfork = yes
+    fruit:delete_empty_adfiles = yes
+    fruit:nfs_aces = no
+    fruit:zero_file_id = yes
+
+    spotlight = no
+    mdns name = mdns
+
+    socket options = TCP_NODELAY IPTOS_LOWDELAY SO_RCVBUF=131072 SO_SNDBUF=131072
+    use sendfile = yes
+    aio read size = 16384
+    aio write size = 16384
+
+    log file = /var/log/samba/log.%m
+    max log size = 1000
+    logging = file
+
+    unix charset = UTF-8
+    dos charset = CP850
+
+[homes]
+    comment = Home Directories
+    browseable = no
+    valid users = %S
+    writable = yes
+    create mask = 0700
+    directory mask = 0700
+    vfs objects = catia fruit streams_xattr
+
+[timemachine]
+    # Time Machine backup destination for macOS
+    path = /mnt/timemachine
+    browseable = yes
+    writable = yes
+    valid users = @sambashare
+
+    fruit:time machine = yes
+    fruit:time machine max size = 450G   # keep < physical disk size
+
+    vfs objects = catia fruit streams_xattr
+    kernel oplocks = no
+    kernel share modes = no
+    posix locking = no
+
+    create mask = 0600
+    directory mask = 0700
+    # NOTE: intentionally NO `force user = nobody` / `force group = nogroup`.
+    # The backup dir is chown'd to the connecting user (jth:jth) instead.


### PR DESCRIPTION
Adds two homelab runbooks captured from the 2026-07-06 session (previously uncommitted on `main`), plus navigation wiring.

## What's here
- **`docs/homelab/nfs-corpus-mount.md`** — mount the corpus NFS export (`/data/corpus` → `/Volumes/corpus`): LAN Bonjour primary, off-LAN NetBird fallback, and manual fallbacks.
- **`docs/homelab/timemachine/`** — working Samba 4.22 Time Machine setup for `jdebian`:
  - `README.md` — full runbook + root-cause writeup (`force user = nobody` + default `fruit:nfs_aces = yes` broke sparsebundle creation with *"backup disk image could not be created"*).
  - `smb.conf` — verbatim working config.
  - `references.md` — the three sources that corroborate the fix.
- **`docs/homelab/README.md`** — pinned `10.0.0.0/24` LAN addressing table (DHCP-reserved 2026-07-23), Incus LAN-primary / NetBird-fallback remotes, TM setup log entry.
- **`docs/INDEX.md` + `README.md`** — new Homelab section + repo-tree entry.

## Notes
- Docs-only; no template or script changes. No secrets — internal LAN/NetBird overlay addresses only, no credentials in `smb.conf`.
- Verified the `INDEX.md` link to `homelab/recovery.md` resolves (file exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)