### PR TITLE
fix(fnm): quiet loglevel + suppress init stderr on shell startup

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -148,7 +148,10 @@ bindkey '^H' backward-kill-word
 # (shipped as dot_node-version = lts/*) so fnm always resolves a default and
 # never errors "Can't find version …" on a fresh deploy or a dir without its
 # own .node-version. Project-local .node-version files still win (nearest match).
-command -v fnm &>/dev/null && eval "$(fnm env --use-on-cd --version-file-strategy recursive)"
+if command -v fnm &>/dev/null; then
+    export FNM_LOGLEVEL=error
+    eval "$(fnm env --use-on-cd --version-file-strategy recursive 2>/dev/null)"
+fi
 
 # Go
 export PATH="$HOME/go/bin:$PATH"


### PR DESCRIPTION
Small follow-on to #64 / #106.

Wraps the `fnm` init in an `if` block, sets `FNM_LOGLEVEL=error`, and redirects `fnm env` stderr so a fresh interactive shell doesn't emit fnm warnings/noise on load.

```diff
-command -v fnm &>/dev/null && eval "$(fnm env --use-on-cd --version-file-strategy recursive)"
+if command -v fnm &>/dev/null; then
+    export FNM_LOGLEVEL=error
+    eval "$(fnm env --use-on-cd --version-file-strategy recursive 2>/dev/null)"
+fi
```

Behavior is otherwise unchanged — recursive version-file resolution and `--use-on-cd` still apply, project-local `.node-version` still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)