### PR TITLE
feat(tailscale): make tailscale.json the deployable source of truth

### DIFF
--- a/tailscale.json
+++ b/tailscale.json
@@ -1,9 +1,61 @@
+// Tailscale policy — tailnet: wolverine-wyrm.ts.net (MagicDNS: tailcdce8.ts.net)
+// SOURCE OF TRUTH. Edit here, commit, then push with:
+//   curl -X POST -u "$TS_API_KEY:" -H "Content-Type: application/hujson" \
+//     --data-binary @tailscale.json https://api.tailscale.com/api/v2/tailnet/-/acl
+//
+// Simplicity is deliberate. Three blocks, nothing else.
 {
-  "grants": [
-    {
-      "src": ["*"],
-      "dst": ["*"],
-      "ip": ["*"]
-    }
-  ]
+	// Who may apply tags. Tagged nodes are owned by the TAILNET, not by a user,
+	// so they never expire and survive the enrolling user leaving. Auth keys
+	// minted with --tags=tag:server produce these.
+	"tagOwners": {
+		"tag:server": ["autogroup:member"],
+	},
+
+	// Network: any node may reach any node on any port.
+	"grants": [
+		{"src": ["*"], "dst": ["*"], "ip": ["*"]},
+
+		// Tailscale Drive (Taildrive): let any node read/write any share.
+		// Shares themselves are still opt-in per node via:
+		//   tailscale drive share <name> <path>
+		{
+			"src": ["*"],
+			"dst": ["*"],
+			"app": {"tailscale.com/cap/drive": [{"shares": ["*"], "access": "rw"}]},
+		},
+	],
+
+	// SSH. "accept", NOT "check".
+	//
+	// !! DO NOT CHANGE THIS TO "check" !!
+	// Tailscale's DEFAULT policy uses "check", which forces a periodic browser
+	// re-authentication ("Tailscale SSH requires an additional check. To
+	// authenticate, visit: https://login.tailscale.com/a/...") per source->dest
+	// pair. That defeats the entire point of this migration: log in to the
+	// tailnet once, then SSH anywhere with no keys, no passwords, no browser.
+	// "accept" is the one and only change from Tailscale's shipped default.
+	//
+	// autogroup:self = every untagged device owned by the authenticating user,
+	// so new machines are authorized the moment they join. No per-host rules.
+	"ssh": [
+		{
+			"action": "accept",
+			"src":    ["autogroup:member"],
+			// autogroup:self covers UNTAGGED user-owned devices only - Tailscale
+			// forbids it for tagged nodes, and forbids wildcards in ssh dst. So
+			// every tag we use must be named here explicitly or SSH to it fails
+			// with: "tailnet policy does not permit you to SSH to this node".
+			"dst":    ["autogroup:self", "tag:server"],
+			"users":  ["autogroup:nonroot", "root"],
+		},
+	],
+
+	// Let members enable Funnel on their own devices (public HTTPS),
+	// and use Tailscale Drive to share and mount directories.
+	//   drive:share  = this device may EXPORT directories
+	//   drive:access = this device may MOUNT others' shares
+	"nodeAttrs": [
+		{"target": ["autogroup:member"], "attr": ["funnel", "drive:share", "drive:access"]},
+	],
 }


### PR DESCRIPTION
Brings `tailscale.json` in the repo up to what is actually deployed on the `wolverine-wyrm.ts.net` tailnet. Verified byte-equivalent against `GET /api/v2/tailnet/-/acl` before opening this PR.

`main` currently holds only the bare permissive grants block. Three additions:

**1. `"action": "accept"`, not `"check"`** — Tailscale's shipped default is `check`, which forces a periodic browser re-auth per source→dest pair. That defeats the whole point of the migration: authenticate to the tailnet once, then SSH anywhere with no keys, no passwords, no browser. This is the single change from the default.

**2. `tag:server` named explicitly in `ssh.dst`** — `autogroup:self` covers *untagged* user-owned devices only; Tailscale forbids it for tagged nodes and prohibits wildcards in SSH `dst`. Until the tag was named here, `ssh lxc155` / `airflow` / `papra` failed with `tailnet policy does not permit you to SSH to this node` while `tailscale ping` succeeded and port 22 was open.

> **Standing rule:** every new tag must be added to `ssh.dst` or SSH to nodes carrying it silently fails. This is the one place the "no per-host rules" property leaks — it is per-*tag*, not per-host, so the cost stays flat.

**3. Taildrive** — the `tailscale.com/cap/drive` grant plus `drive:share` / `drive:access` nodeAttrs. Shares stay opt-in per node via `tailscale drive share <name> <path>`.

No `"recorder"` clauses anywhere — a recorder clause terminates the SSH session if no recorder node is live.

Pairs with dotfiles #123 (autodeployment) as tracked in #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDMyXyfKAouJvSf6NwqZi4