### PR TITLE
chore(gitignore): ignore agent worktrees, bytecode, backups, and NetBird API dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,19 @@ dot_aws/
 Dockerfile.test
 #Worktrees
 .worktrees
+
+# Agent worktrees (.worktrees above covers the old location only)
+.claude/worktrees/
+
+# Python bytecode
+__pycache__/
+*.pyc
+
+# Editor / tool backups
+*.bak
+*.bak.nup
+
+# NetBird API dumps — kept locally, never published. peers.json carries public
+# WAN IPs, hardware serial numbers and city-level geolocation, and this repo is
+# PUBLIC. Re-generate with scripts/homelab/netbird-policy-cleanup.py.
+scripts/homelab/netbird-backup/


### PR DESCRIPTION
**This repo is public**, and `scripts/homelab/netbird-backup/` holds raw NetBird API dumps. Its `peers.json` carries two public WAN IPs, nine hardware serial numbers, and city-level geolocation across a 42-peer inventory. Ignoring it — the dumps stay on disk and are regenerable from the API via `scripts/homelab/netbird-policy-cleanup.py`.

Also:
- `.claude/worktrees/` — `.worktrees` was already ignored, but agents now create worktrees under `.claude/`, and three live ones were showing as untracked.
- `__pycache__/`, `*.pyc`, `*.bak`, `*.bak.nup`.

Split out from the wider homelab work so the protection lands on `main` on its own — it is one file and contains no topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDMyXyfKAouJvSf6NwqZi4